### PR TITLE
feat: retrieving multiple signing keys

### DIFF
--- a/pg-cli/src/client.rs
+++ b/pg-cli/src/client.rs
@@ -149,16 +149,16 @@ impl<'a> Client<'a> {
     pub async fn request_signing_key(
         &self,
         auth: &str,
-    ) -> Result<KeyResponse<SigningKeyExt>, ClientError> {
+    ) -> Result<KeyResponse<Vec<SigningKeyExt>>, ClientError> {
         let res = self
             .client
-            .get(self.create_url("v2/irma/sign/key"))
+            .post(self.create_url("v2/irma/sign/key"))
             .bearer_auth(auth)
             .headers(HEADERS.clone())
             .send()
             .await?
             .error_for_status()?
-            .json::<KeyResponse<SigningKeyExt>>()
+            .json::<KeyResponse<Vec<SigningKeyExt>>>()
             .await?;
 
         Ok(res)
@@ -187,16 +187,16 @@ impl<'a> Client<'a> {
         Err(ClientError::Timeout)
     }
 
-    pub async fn wait_on_signing_key(
+    pub async fn wait_on_signing_keys(
         &self,
         sp: &irma::SessionData,
-    ) -> Result<KeyResponse<SigningKeyExt>, ClientError> {
+    ) -> Result<KeyResponse<Vec<SigningKeyExt>>, ClientError> {
         for _ in 0..120 {
             let jwt: String = self.request_jwt(&sp.token).await?;
             let kr = self.request_signing_key(&jwt).await?;
 
             match kr {
-                kr @ KeyResponse::<SigningKeyExt> {
+                kr @ KeyResponse::<Vec<SigningKeyExt>> {
                     status: irma::SessionStatus::Done,
                     ..
                 } => return Ok(kr),

--- a/pg-cli/src/encrypt.rs
+++ b/pg-cli/src/encrypt.rs
@@ -1,4 +1,4 @@
-use pg_core::api::{IrmaAuthRequest, SignBody};
+use pg_core::api::{IrmaAuthRequest, SigningKeyRequest, SigningKeyResponse};
 use pg_core::client::rust::stream::SealerStreamConfig;
 use pg_core::client::Sealer;
 use pg_core::identity::{Attribute, Policy};
@@ -25,7 +25,7 @@ pub async fn exec(enc_opts: EncOpts) {
     let EncOpts {
         input,
         identity,
-        pub_sign_id,
+        pub_sign_id: pub_sign_id_str,
         priv_sign_id,
         pkg,
     } = enc_opts;
@@ -47,11 +47,11 @@ pub async fn exec(enc_opts: EncOpts) {
         })
         .collect();
 
-    let pub_sig_id: Vec<Attribute> = serde_json::from_str(&pub_sign_id).unwrap();
-    let mut total_id = pub_sig_id.clone();
+    let pub_sign_id: Vec<Attribute> = serde_json::from_str(&pub_sign_id_str).unwrap();
+    let mut total_id = pub_sign_id.clone();
 
-    let priv_sig_id = if let Some(priv_id_str) = priv_sign_id {
-        let priv_id: Vec<Attribute> = serde_json::from_str(&priv_id_str).unwrap();
+    let priv_sign_id = if let Some(priv_sign_id_str) = priv_sign_id {
+        let priv_id: Vec<Attribute> = serde_json::from_str(&priv_sign_id_str).unwrap();
         total_id.extend(priv_id.clone());
         Some(priv_id)
     } else {
@@ -80,18 +80,16 @@ pub async fn exec(enc_opts: EncOpts) {
 
     print_qr(&sd.session_ptr);
 
-    let body = priv_sig_id.map(|id| SignBody {
-        subsets: vec![pub_sig_id, id],
-    });
+    let skr = SigningKeyRequest {
+        pub_sign_id,
+        priv_sign_id,
+    };
 
-    let keys = client
-        .wait_on_signing_keys(&sd, &body)
-        .await
-        .unwrap()
-        .key
-        .unwrap();
-
-    let pub_sign_key = &keys[0];
+    let SigningKeyResponse {
+        pub_sign_key,
+        priv_sign_key,
+        ..
+    } = client.wait_on_signing_keys(&sd, &skr).await.unwrap();
 
     let input_path = Path::new(&input);
     let file_name_path = input_path.file_name().unwrap();
@@ -116,13 +114,13 @@ pub async fn exec(enc_opts: EncOpts) {
     let mut sealer = Sealer::<_, SealerStreamConfig>::new(
         &parameters.public_key,
         &policies,
-        &pub_sign_key,
+        &pub_sign_key.expect("no public signing key"),
         &mut rng,
     )
     .unwrap();
 
-    if keys.len() == 2 {
-        sealer = sealer.with_priv_signing_key(keys[1].clone());
+    if let Some(psk) = priv_sign_key {
+        sealer = sealer.with_priv_signing_key(psk);
     };
 
     sealer.seal(r, w).await.unwrap();

--- a/pg-core/src/api.rs
+++ b/pg-core/src/api.rs
@@ -1,6 +1,6 @@
 //! Definitions of the PostGuard protocol REST API.
 
-use crate::identity::Attribute;
+use crate::{artifacts::SigningKeyExt, identity::Attribute};
 use alloc::vec::Vec;
 use irma::{ProofStatus, SessionStatus};
 use serde::{Deserialize, Serialize};
@@ -42,9 +42,35 @@ pub struct KeyResponse<T> {
     pub key: Option<T>,
 }
 
-/// Signing request body.
+/// The request Signing key request body.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct SignBody {
-    /// The subsets.
-    pub subsets: Vec<Vec<Attribute>>,
+#[serde(rename_all = "camelCase")]
+pub struct SigningKeyRequest {
+    /// The public signing identity.
+    pub pub_sign_id: Vec<Attribute>,
+
+    /// The private signing identity.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priv_sign_id: Option<Vec<Attribute>>,
+}
+
+/// The signing key response from the Private Key Generator (PKG).
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SigningKeyResponse {
+    /// The status of the session.
+    pub status: SessionStatus,
+
+    /// The status of the IRMA proof.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proof_status: Option<ProofStatus>,
+
+    /// The public signing key.
+    /// The key will remain `None` until the status is `Done` and the proof is `Valid`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pub_sign_key: Option<SigningKeyExt>,
+
+    /// This private signing key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priv_sign_key: Option<SigningKeyExt>,
 }

--- a/pg-core/src/api.rs
+++ b/pg-core/src/api.rs
@@ -41,3 +41,10 @@ pub struct KeyResponse<T> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub key: Option<T>,
 }
+
+/// Signing request body.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SignBody {
+    /// The subsets.
+    pub subsets: Vec<Vec<Attribute>>,
+}

--- a/pg-pkg/README.md
+++ b/pg-pkg/README.md
@@ -92,10 +92,11 @@ The `status` field will always be included. The `proofStatus` and `key` values
 are optional and depend on the JWT. A key is included if and only if the proof
 was valid and all the claimed attributes were present. A key is derived from these attributes.
 
-### `GET /v2/irma/sign/key`
+### `POST /v2/irma/sign/key`
 
-Retrieves a signing key. The request must include a HTTP Authorization header
+Retrieves signing key(s). The request must include a HTTP Authorization header
 `Authorization: Bearer <JWT>`.
 
 The response looks similar as `GET /v2/irma/key/{timestamp}`, except the key is
-a signing key.
+a signing key. If a JSON body with subsets of attributes are sent, the response
+wil contain multiple keys.

--- a/pg-pkg/README.md
+++ b/pg-pkg/README.md
@@ -95,8 +95,36 @@ was valid and all the claimed attributes were present. A key is derived from the
 ### `POST /v2/irma/sign/key`
 
 Retrieves signing key(s). The request must include a HTTP Authorization header
-`Authorization: Bearer <JWT>`.
+`Authorization: Bearer <JWT>`. The body must include under which identities a user wants to sign.
 
-The response looks similar as `GET /v2/irma/key/{timestamp}`, except the key is
-a signing key. If a JSON body with subsets of attributes are sent, the response
-wil contain multiple keys.
+```JSON
+{
+  "pubSignId": [
+    { "t": "irma-demo.gemeente.personalData.fullname", "v": "Alice" }
+  ],
+  "privSignId": [{ "t": "irma-demo.gemeente.personalData.bsn", "v": "1234" }]
+}
+```
+
+The response looks similar as `GET /v2/irma/key/{timestamp}`, except with signing keys.
+
+```JSON
+{
+  "status": "DONE",
+  "proofStatus": "VALID",
+  "pubSignKey": {
+    "key": "/VBSvTSsTloj5xUKH1EDWN1s6c9Z5L1UqL2NGJnpaQMoFa2sjLw+cjA8P5OD3AwP7zv1VcU7Tzon/8J/vnVLbzGNswBZk5KAjYZVrFNZx34/5Hbk28ajjqVA4fKqNawB",
+    "policy": {
+      "ts": 1695723474,
+      "con": [{ "t": "irma-demo.gemeente.personalData.fullname", "v": "Alice" }]
+    }
+  },
+  "privSignKey": {
+    "key": "Uk+BFli0n5yz8huZCQWiztgdo3KvN9Y6XcsPc+IAmARKXGUApvaYYTCi+7WdjxZzXs1mnrAas3r5wuWu2ecuQaSyboyIuCbGD/P7+FO1rc712czlVm6RxKrZx4BjlsqU",
+    "policy": {
+      "ts": 1695723474,
+      "con": [{ "t": "irma-demo.gemeente.personalData.bsn", "v": "1234" }]
+    }
+  }
+}
+```

--- a/pg-pkg/src/handlers/signing_key.rs
+++ b/pg-pkg/src/handlers/signing_key.rs
@@ -1,18 +1,25 @@
-use actix_web::{web::Data, HttpResponse};
+use actix_web::{web::Data, web::Json, HttpResponse};
 use actix_web::{HttpMessage, HttpRequest};
+use serde::Deserialize;
 
 use pg_core::api::KeyResponse;
 use pg_core::artifacts::{SigningKey, SigningKeyExt};
-use pg_core::identity::Policy;
+use pg_core::identity::{Attribute, Policy};
 
 use pg_core::ibs::gg::{keygen, Identity, SecretKey};
 
 use crate::middleware::irma::IrmaAuthResult;
 use crate::util::current_time_u64;
 
+#[derive(Debug, Deserialize)]
+pub struct Body {
+    subsets: Vec<Vec<Attribute>>,
+}
+
 pub async fn signing_key(
     req: HttpRequest,
     msk: Data<SecretKey>,
+    body: Option<Json<Body>>,
 ) -> Result<HttpResponse, crate::Error> {
     let sk = msk.get_ref();
     let mut rng = rand::thread_rng();
@@ -33,22 +40,43 @@ pub async fn signing_key(
     // The PKG gets to decide the timestamp in the policy.
     let iat = current_time_u64()?;
 
-    let policy = Policy {
-        timestamp: iat,
-        con,
-    };
+    let mut keys = vec![];
 
-    let derived = policy.derive_ibs().map_err(|_e| crate::Error::Unexpected)?;
+    if let Some(x) = body {
+        for p in x.subsets.iter() {
+            if p.iter().all(|at| con.contains(at)) {
+                let policy = Policy {
+                    timestamp: iat,
+                    con: p.clone(),
+                };
+                let id = policy.derive_ibs().map_err(|_e| crate::Error::Unexpected)?;
+                let key = keygen(sk, &id, &mut rng);
 
-    let id = Identity::from(derived);
-    let key = keygen(sk, &id, &mut rng);
+                keys.push(SigningKeyExt {
+                    key: SigningKey(key),
+                    policy,
+                });
+            }
+        }
+    } else {
+        let policy = Policy {
+            timestamp: iat,
+            con,
+        };
 
-    Ok(HttpResponse::Ok().json(KeyResponse::<SigningKeyExt> {
-        status,
-        proof_status,
-        key: Some(SigningKeyExt {
+        let derived = policy.derive_ibs().map_err(|_e| crate::Error::Unexpected)?;
+
+        let id = Identity::from(derived);
+        let key = keygen(sk, &id, &mut rng);
+        keys.push(SigningKeyExt {
             key: SigningKey(key),
             policy,
-        }),
+        });
+    }
+
+    Ok(HttpResponse::Ok().json(KeyResponse::<Vec<SigningKeyExt>> {
+        status,
+        proof_status,
+        key: Some(keys),
     }))
 }

--- a/pg-pkg/src/handlers/signing_key.rs
+++ b/pg-pkg/src/handlers/signing_key.rs
@@ -2,7 +2,7 @@ use actix_web::{web::Data, web::Json, HttpResponse};
 use actix_web::{HttpMessage, HttpRequest};
 use serde::Deserialize;
 
-use pg_core::api::KeyResponse;
+use pg_core::api::{KeyResponse, SignBody};
 use pg_core::artifacts::{SigningKey, SigningKeyExt};
 use pg_core::identity::{Attribute, Policy};
 
@@ -11,15 +11,10 @@ use pg_core::ibs::gg::{keygen, Identity, SecretKey};
 use crate::middleware::irma::IrmaAuthResult;
 use crate::util::current_time_u64;
 
-#[derive(Debug, Deserialize)]
-pub struct Body {
-    subsets: Vec<Vec<Attribute>>,
-}
-
 pub async fn signing_key(
     req: HttpRequest,
     msk: Data<SecretKey>,
-    body: Option<Json<Body>>,
+    body: Option<Json<SignBody>>,
 ) -> Result<HttpResponse, crate::Error> {
     let sk = msk.get_ref();
     let mut rng = rand::thread_rng();

--- a/pg-pkg/src/handlers/signing_key.rs
+++ b/pg-pkg/src/handlers/signing_key.rs
@@ -1,12 +1,11 @@
 use actix_web::{web::Data, web::Json, HttpResponse};
 use actix_web::{HttpMessage, HttpRequest};
-use serde::Deserialize;
 
-use pg_core::api::{KeyResponse, SignBody};
+use irma::SessionStatus;
+use pg_core::api::{SigningKeyRequest, SigningKeyResponse};
 use pg_core::artifacts::{SigningKey, SigningKeyExt};
-use pg_core::identity::{Attribute, Policy};
-
-use pg_core::ibs::gg::{keygen, Identity, SecretKey};
+use pg_core::ibs::gg::{keygen, SecretKey};
+use pg_core::identity::Policy;
 
 use crate::middleware::irma::IrmaAuthResult;
 use crate::util::current_time_u64;
@@ -14,7 +13,7 @@ use crate::util::current_time_u64;
 pub async fn signing_key(
     req: HttpRequest,
     msk: Data<SecretKey>,
-    body: Option<Json<SignBody>>,
+    body: Json<SigningKeyRequest>,
 ) -> Result<HttpResponse, crate::Error> {
     let sk = msk.get_ref();
     let mut rng = rand::thread_rng();
@@ -34,44 +33,60 @@ pub async fn signing_key(
 
     // The PKG gets to decide the timestamp in the policy.
     let iat = current_time_u64()?;
+    let body = body.into_inner();
 
-    let mut keys = vec![];
-
-    if let Some(x) = body {
-        for p in x.subsets.iter() {
-            if p.iter().all(|at| con.contains(at)) {
-                let policy = Policy {
-                    timestamp: iat,
-                    con: p.clone(),
-                };
-                let id = policy.derive_ibs().map_err(|_e| crate::Error::Unexpected)?;
-                let key = keygen(sk, &id, &mut rng);
-
-                keys.push(SigningKeyExt {
-                    key: SigningKey(key),
-                    policy,
-                });
-            }
+    match status {
+        SessionStatus::Done => (),
+        _ => {
+            return Ok(HttpResponse::Ok().json(SigningKeyResponse {
+                status,
+                proof_status,
+                pub_sign_key: None,
+                priv_sign_key: None,
+            }))
         }
-    } else {
-        let policy = Policy {
-            timestamp: iat,
-            con,
-        };
-
-        let derived = policy.derive_ibs().map_err(|_e| crate::Error::Unexpected)?;
-
-        let id = Identity::from(derived);
-        let key = keygen(sk, &id, &mut rng);
-        keys.push(SigningKeyExt {
-            key: SigningKey(key),
-            policy,
-        });
     }
 
-    Ok(HttpResponse::Ok().json(KeyResponse::<Vec<SigningKeyExt>> {
+    if !body.pub_sign_id.iter().all(|attr| con.contains(attr)) {
+        return Err(crate::Error::Unexpected);
+    }
+
+    let policy = Policy {
+        timestamp: iat,
+        con: body.pub_sign_id.clone(),
+    };
+    let id = policy.derive_ibs().map_err(|_e| crate::Error::Unexpected)?;
+    let key = keygen(sk, &id, &mut rng);
+
+    let pub_sign_key = SigningKeyExt {
+        key: SigningKey(key),
+        policy,
+    };
+
+    let priv_sign_key = body.priv_sign_id.map(|priv_sign_id| {
+        if !priv_sign_id.iter().all(|attr| con.contains(attr)) {
+            return Err(crate::Error::Unexpected);
+        }
+        let policy = Policy {
+            timestamp: iat,
+            con: priv_sign_id,
+        };
+
+        let id = policy.derive_ibs().map_err(|_e| crate::Error::Unexpected)?;
+        let key = keygen(sk, &id, &mut rng);
+
+        Ok(SigningKeyExt {
+            key: SigningKey(key),
+            policy,
+        })
+    });
+
+    let priv_sign_key = priv_sign_key.map_or(Ok(None), |r| r.map(Some))?;
+
+    Ok(HttpResponse::Ok().json(SigningKeyResponse {
         status,
         proof_status,
-        key: Some(keys),
+        pub_sign_key: Some(pub_sign_key),
+        priv_sign_key,
     }))
 }

--- a/pg-pkg/src/middleware/irma_noauth.rs
+++ b/pg-pkg/src/middleware/irma_noauth.rs
@@ -3,24 +3,26 @@
 //! simply extracts an identity from a IRMA policy contained in the request. The identity is passed
 //! to the key service using the request extensions.
 
+use actix_http::h1::Payload;
 use actix_web::{
     dev::{forward_ready, Service, ServiceRequest, ServiceResponse, Transform},
-    web::Json,
+    web::{BytesMut, Json},
     Error, HttpMessage,
 };
 
 use futures::future::{ready, Ready};
 use futures::FutureExt;
-use futures_util::future::LocalBoxFuture;
+use futures_util::{future::LocalBoxFuture, StreamExt};
 use std::rc::Rc;
 
 use crate::middleware::irma::IrmaAuthResult;
 use irma::ProofStatus;
-use pg_core::identity::Policy;
+use pg_core::{api::SigningKeyRequest, identity::Policy};
 
 #[doc(hidden)]
 pub struct NoAuthService<S> {
     service: Rc<S>,
+    sort: Rc<NoAuth>,
 }
 
 impl<S> Service<ServiceRequest> for NoAuthService<S>
@@ -35,10 +37,35 @@ where
 
     fn call(&self, mut req: ServiceRequest) -> Self::Future {
         let srv = self.service.clone();
+        let sort = self.sort.clone();
 
         async move {
             // Retrieve the policy from the request.
-            let pol = req.extract::<Json<Policy>>().await?.into_inner();
+            let pol = match &*sort {
+                NoAuth::Decryption => req.extract::<Json<Policy>>().await?.into_inner(),
+                NoAuth::Signing => {
+                    let mut body = BytesMut::new();
+                    let mut stream = req.take_payload();
+
+                    while let Some(chunk) = stream.next().await {
+                        body.extend_from_slice(&chunk?);
+                    }
+
+                    let skr = serde_json::from_slice::<SigningKeyRequest>(&body)?;
+
+                    let (_, mut payload) = Payload::create(true);
+                    payload.unread_data(body.into());
+                    req.set_payload(payload.into());
+
+                    let mut con = vec![];
+                    con.extend(skr.pub_sign_id);
+                    if let Some(priv_id) = skr.priv_sign_id {
+                        con.extend(priv_id);
+                    }
+
+                    Policy { timestamp: 0, con }
+                }
+            };
 
             // Pass the result to the key service, which expects it in the extensions.
             req.extensions_mut().insert(IrmaAuthResult {
@@ -57,12 +84,10 @@ where
     }
 }
 
-pub struct NoAuth;
-
-impl NoAuth {
-    pub fn new() -> Self {
-        NoAuth {}
-    }
+#[derive(Clone)]
+pub enum NoAuth {
+    Decryption,
+    Signing,
 }
 
 impl<S> Transform<S, ServiceRequest> for NoAuth
@@ -78,6 +103,7 @@ where
     fn new_transform(&self, service: S) -> Self::Future {
         ready(Ok(NoAuthService {
             service: Rc::new(service),
+            sort: Rc::new(self.clone()),
         }))
     }
 }


### PR DESCRIPTION
- changes the `/sign/key` endpoint to `POST`,
- a body is mandatory and should have conjunctions for the public and private signing keys in the request,
- the PKG will respond with both keys iff all the attributes are a subset of the disclosed attributes.

- [x] update pg-cli to support this change.