### PR TITLE
Add multi-platform Docker builds (AMD64 + ARM64)

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -54,6 +54,7 @@ jobs:
               with:
                   context: .
                   load: true
+                  platforms: linux/amd64
                   tags: local/go-passport-issuer:scan
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
@@ -78,6 +79,10 @@ jobs:
               uses: docker/build-push-action@v5
               if: ${{ github.event_name == 'release' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
               with:
+                  context: .
                   push: true
+                  platforms: linux/amd64,linux/arm64
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Enables multi-platform Docker image builds for both `linux/amd64` and `linux/arm64` architectures
- Fixes the issue where Docker images could not run on Apple Silicon Macs

## Changes
- Updated `.github/workflows/delivery.yml` to build multi-platform images
- Scan step remains AMD64-only (required for `load: true` compatibility)
- Push step now builds for both AMD64 and ARM64 platforms
- Added cache configuration to push step for consistency

## Benefits
- Users on Apple Silicon Macs can run `docker run ghcr.io/encryption4all/postguard:edge` without platform emulation
- No performance penalty from Rosetta translation on ARM64 systems
- Maintains backward compatibility with existing AMD64 users

## Testing
Once merged and the workflow runs, the published images will include a multi-platform manifest that automatically serves the correct architecture.