### PR TITLE
Make SonarQube and Safari WASM tests non-blocking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
   sonarqube:
     name: SonarQube
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,6 +57,7 @@ jobs:
           - browser: safari
             os: macos-latest
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.browser == 'safari' }}
     env:
       WASM_BINDGEN_TEST_TIMEOUT: 120
     steps:


### PR DESCRIPTION
## Summary
Temporary fix to allow Dependabot PRs to pass CI checks.

## Changes
- Make SonarQube job non-blocking (`continue-on-error: true`)
- Make Safari WASM test non-blocking (only Safari, Chrome/Firefox remain required)

## Rationale
Both checks are currently failing and blocking all PRs, including Dependabot security updates:

1. **SonarQube** - Authentication token is failing (HTTP 403)
   - Tracked in: #48
   
2. **Safari WASM tests** - Failing on macOS runners
   - Tracked in: #49

These checks will continue to run and report results, but won't block PR merges while the underlying issues are being fixed.

## Next Steps
Once #48 and #49 are resolved, we should revert this change to make these checks blocking again.