### PR TITLE
Split Safari WASM test into separate job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,16 +48,11 @@ jobs:
       - run: cargo fmt --manifest-path pg-${{ matrix.workspace }}/Cargo.toml --all -- --check
 
   test-wasm-browsers:
-    name: Run wasm tests in browsers
+    name: Run wasm tests in browsers (Chrome, Firefox)
     strategy:
       matrix:
         browser: [chrome, firefox]
-        os: [ubuntu-latest]
-        include:
-          - browser: safari
-            os: macos-latest
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.browser == 'safari' }}
+    runs-on: ubuntu-latest
     env:
       WASM_BINDGEN_TEST_TIMEOUT: 120
     steps:
@@ -68,3 +63,15 @@ jobs:
       - if: ${{ matrix.browser == 'firefox' }}
         run: sudo apt update && sudo apt install firefox
       - run: wasm-pack test --release --headless --${{ matrix.browser }} ./pg-wasm
+
+  test-wasm-safari:
+    name: Run wasm tests in Safari
+    runs-on: macos-latest
+    continue-on-error: true
+    env:
+      WASM_BINDGEN_TEST_TIMEOUT: 120
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - run: wasm-pack test --release --headless --safari ./pg-wasm


### PR DESCRIPTION
## Summary
Fix for Safari WASM test continue-on-error not working with matrix strategy.

## Changes
Split WASM browser tests into two separate jobs:
- **test-wasm-browsers** - Chrome & Firefox (required, will block PRs if failing)
- **test-wasm-safari** - Safari only (non-blocking with `continue-on-error: true`)

## Context
In PR #51, we tried to make Safari non-blocking using:
```yaml
continue-on-error: ${{ matrix.browser == 'safari' }}
```

This approach didn't work correctly. By splitting Safari into its own job, the `continue-on-error: true` setting now properly prevents Safari test failures from blocking PRs.

## Related
- Fixes the Safari portion of the temporary fix from #51
- Related to issue #49 (Safari WASM tests failing)