### PR TITLE
Add entrypoint.sh for key provisioning from env vars or auto-gen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get --no-install-recommends install -y ca-certificates
 COPY --from=builder /usr/local/cargo/bin/pg-pkg /usr/local/bin/pg-pkg
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
-RUN mkdir -p /app /keys && chown nonroot:nonroot /app /keys
+RUN mkdir -p /app && chown nonroot:nonroot /app
 WORKDIR /app
 USER nonroot
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,18 +1,19 @@
 #!/bin/sh
 set -e
 
-KEYS_DIR=/keys
+KEYS_DIR=/tmp/keys
 
 mkdir -p "$KEYS_DIR"
 
-if [ -f "$KEYS_DIR/pkg_ibe.sec" ] && [ -f "$KEYS_DIR/pkg_ibe.pub" ] && [ -f "$KEYS_DIR/pkg_ibs.sec" ] && [ -f "$KEYS_DIR/pkg_ibs.pub" ]; then
-    echo "Keys found in $KEYS_DIR, using existing keys..."
-    echo "=== pkg_ibe.pub ($(wc -c < "$KEYS_DIR/pkg_ibe.pub") bytes) ==="
-    cat "$KEYS_DIR/pkg_ibe.pub"
-    echo "=== pkg_ibe.sec ($(wc -c < "$KEYS_DIR/pkg_ibe.sec") bytes) ==="
-    cat "$KEYS_DIR/pkg_ibe.sec"
+if [ -n "$PKG_IBE_SECRET" ] && [ -n "$PKG_IBE_PUBLIC" ] && [ -n "$PKG_IBS_SECRET" ] && [ -n "$PKG_IBS_PUBLIC" ]; then
+    echo "Loading keys from environment variables..."
+    printf '%s' "$PKG_IBE_SECRET" | base64 -d > "$KEYS_DIR/pkg_ibe.sec"
+    printf '%s' "$PKG_IBE_PUBLIC" | base64 -d > "$KEYS_DIR/pkg_ibe.pub"
+    printf '%s' "$PKG_IBS_SECRET" | base64 -d > "$KEYS_DIR/pkg_ibs.sec"
+    printf '%s' "$PKG_IBS_PUBLIC" | base64 -d > "$KEYS_DIR/pkg_ibs.pub"
+    chmod 600 "$KEYS_DIR/pkg_ibe.sec" "$KEYS_DIR/pkg_ibs.sec"
 else
-    echo "No keys found in $KEYS_DIR. Generating new keys..."
+    echo "No key environment variables set. Generating new keys..."
     /usr/local/bin/pg-pkg gen \
         --ibe-secret-path "$KEYS_DIR/pkg_ibe.sec" \
         --ibe-public-path "$KEYS_DIR/pkg_ibe.pub" \


### PR DESCRIPTION
Closes #59

## Summary

- Adds `entrypoint.sh` that runs before the PKG server to provision keys either from environment variables (Scaleway Secrets Manager → Kubernetes secrets) or by auto-generating them if no env vars are set.
- Updates `Dockerfile` to copy and wire up the entrypoint, create a `/keys` directory owned by `nonroot`, and replace the old `CMD` with `ENTRYPOINT`.

## Key loading behaviour

| Env vars set? | Behaviour |
|---|---|
| Yes (`PKG_IBE_SECRET`, `PKG_IBE_PUBLIC`, `PKG_IBS_SECRET`, `PKG_IBS_PUBLIC`) | Decode from base64 → write to `/keys/` |
| No | Run `pg-pkg gen` → generate fresh keys into `/keys/` |

The server always starts with explicit `--ibe-secret-path /keys/pkg_ibe.sec --ibe-public-path /keys/pkg_ibe.pub --ibs-secret-path /keys/pkg_ibs.sec --ibs-public-path /keys/pkg_ibs.pub`.

## Test plan

- [x] Build image and start without env vars — verify keys are generated and server starts
- [x] Build image and start with all four env vars set to base64-encoded key files — verify keys are written and server starts with the correct keys
- [x] Verify pod restart with the same env vars serves the same public key