### PR TITLE
Automate pg-wasm npm publishing via GitHub Releases

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -163,6 +163,15 @@ jobs:
               id: version
               run: echo "version=${GITHUB_REF_NAME#pg-wasm-v}" >> "$GITHUB_OUTPUT"
 
+            - name: Verify Cargo.toml version matches tag
+              run: |
+                  cargo_version=$(grep '^version' pg-wasm/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+                  tag_version="${{ steps.version.outputs.version }}"
+                  if [ "$cargo_version" != "$tag_version" ]; then
+                      echo "::error::Version mismatch: Cargo.toml has $cargo_version but tag says $tag_version"
+                      exit 1
+                  fi
+
             - name: Install Rust toolchain
               uses: dtolnay/rust-toolchain@stable
 
@@ -170,7 +179,7 @@ jobs:
               run: cargo install wasm-pack
 
             - name: Build pg-wasm
-              run: wasm-pack build --release -d pkg/ --out-name index --scope e4a --target bundler ./pg-wasm
+              run: wasm-pack build --release -d pkg/ --out-name index --scope e4a --target web ./pg-wasm
 
             - name: Set version from tag
               run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -150,3 +150,40 @@ jobs:
                       $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
                       "ghcr.io/${{ github.repository }}@${{ needs.build-amd64.outputs.digest }}" \
                       "ghcr.io/${{ github.repository }}@${{ needs.build-arm64.outputs.digest }}"
+
+    publish-pg-wasm:
+        name: Publish pg-wasm to npm
+        runs-on: ubuntu-latest
+        if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'pg-wasm-v') }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Extract version from tag
+              id: version
+              run: echo "version=${GITHUB_REF_NAME#pg-wasm-v}" >> "$GITHUB_OUTPUT"
+
+            - name: Install Rust toolchain
+              uses: dtolnay/rust-toolchain@stable
+
+            - name: Install wasm-pack
+              run: cargo install wasm-pack
+
+            - name: Build pg-wasm
+              run: wasm-pack build --release -d pkg/ --out-name index --scope e4a --target bundler ./pg-wasm
+
+            - name: Set version from tag
+              run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+              working-directory: pg-wasm/pkg
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  registry-url: https://registry.npmjs.org
+
+            - name: Publish to npm
+              run: npm publish --access public
+              working-directory: pg-wasm/pkg
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "pg-wasm"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "futures 0.3.32",
  "getrandom 0.2.17",

--- a/pg-wasm/Cargo.toml
+++ b/pg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-wasm"
-version = "0.3.0"
+version = "0.5.0"
 authors = [
   "Leon Botros <l.botros@cs.ru.nl>",
   "Bas Westerbaan <bas@westerbaan.name>",


### PR DESCRIPTION
## Summary

- Adds a `publish-pg-wasm` job to `delivery.yml` that automatically publishes `@e4a/pg-wasm` to npm when a GitHub Release is created with a `pg-wasm-v*` tag
- The npm version is extracted from the git tag.
- Add check to make sure the cargo.toml and git tag are the same version.

## Release process

1. Bump version in `pg-wasm/Cargo.toml` on `main`
2. Create a GitHub Release with tag `pg-wasm-v{version}` (e.g. `pg-wasm-v0.5.0`)
3. CI automatically builds and publishes to npm

## Setup required

- [x] Add this repo as trusted publisher in npmjs

Closes #65