### PR TITLE
feat: sync pg-core and pg-wasm versions, exclude pg-wasm from workspace

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       releases_created: ${{ steps.release-plz.outputs.releases_created }}
       pg_pkg_version: ${{ steps.parse.outputs.pg_pkg_version }}
-      pg_wasm_version: ${{ steps.parse.outputs.pg_wasm_version }}
+      pg_core_version: ${{ steps.parse.outputs.pg_core_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -54,9 +54,9 @@ jobs:
         run: |
           RELEASES='${{ steps.release-plz.outputs.releases }}'
           PG_PKG_VERSION=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "pg-pkg") | .version // empty')
-          PG_WASM_VERSION=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "pg-wasm") | .version // empty')
+          PG_CORE_VERSION=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "pg-core") | .version // empty')
           echo "pg_pkg_version=$PG_PKG_VERSION" >> "$GITHUB_OUTPUT"
-          echo "pg_wasm_version=$PG_WASM_VERSION" >> "$GITHUB_OUTPUT"
+          echo "pg_core_version=$PG_CORE_VERSION" >> "$GITHUB_OUTPUT"
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
@@ -228,10 +228,14 @@ jobs:
   # npm: publish pg-wasm to npmjs
   # ---------------------------------------------------------------------------
 
+  # pg-wasm is excluded from the workspace because pg-core's "web" feature
+  # uses compile_error! on non-wasm32 targets, making cargo package fail.
+  # pg-wasm's npm version is kept in sync with pg-core: when pg-core is
+  # released, pg-wasm is published at the same version.
   publish-wasm:
     name: Publish pg-wasm to npm
     needs: release-plz-release
-    if: needs.release-plz-release.outputs.pg_wasm_version != ''
+    if: needs.release-plz-release.outputs.pg_core_version != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -296,7 +300,7 @@ jobs:
       - name: Set version and publish
         working-directory: pg-wasm/pkg
         run: |
-          npm version "${{ needs.release-plz-release.outputs.pg_wasm_version }}" --no-git-tag-version
+          npm version "${{ needs.release-plz-release.outputs.pg_core_version }}" --no-git-tag-version
           npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
-members = ["pg-core", "pg-cli", "pg-pkg", "pg-wasm"]
-default-members = ["pg-core", "pg-cli", "pg-pkg"]
+members = ["pg-core", "pg-cli", "pg-pkg"]
+exclude = ["pg-wasm"]
 
 resolver = "2"
 

--- a/pg-cli/Cargo.toml
+++ b/pg-cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "pg-cli"
 version = "0.3.1"
 
 [dependencies]
-pg-core = { path = "../pg-core", version = "0.3.1", features = ["stream"] }
+pg-core = { path = "../pg-core", version = "0.5.6", features = ["stream"] }
 futures = "0.3.27"
 rand = "0.8.4"
 clap = { version = "4", features = ["derive"] }

--- a/pg-core/Cargo.toml
+++ b/pg-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pg-core"
 description = "PostGuard core library communication and bytestream operations."
-version = "0.3.1"
+version = "0.5.6"
 authors = [
   "Leon Botros <l.botros@cs.ru.nl>",
   "Wouter Geraedts <git@woutergeraedts.nl>",

--- a/pg-pkg/Cargo.toml
+++ b/pg-pkg/Cargo.toml
@@ -48,5 +48,5 @@ version = "0.3"
 
 [dependencies.pg-core]
 path = "../pg-core"
-version = "0.3"
+version = "0.5.6"
 features = []

--- a/pg-wasm/Cargo.toml
+++ b/pg-wasm/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["ibe", "encryption", "ecc"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pg-core = { path = "../pg-core", version = "0.3", features = ["web", "stream"] }
+pg-core = { path = "../pg-core", version = "0.5.6", features = ["web", "stream"] }
 wasm-bindgen = { version = "0.2.104" }
 js-sys = "0.3"
 web-sys = "0.3"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -16,9 +16,3 @@ publish = true
 name = "pg-pkg"
 publish = false
 git_only = true
-
-# pg-wasm: npm only, no crates.io publish
-[[package]]
-name = "pg-wasm"
-publish = false
-git_only = true


### PR DESCRIPTION
## Summary

- Bumps pg-core from 0.3.1 to 0.5.6 (above pg-wasm's current npm version 0.5.5)
- Excludes pg-wasm from workspace (pg-core's `web` feature uses `compile_error!` on non-wasm32 targets)
- Removes pg-wasm from release-plz config
- **pg-wasm npm version now follows pg-core**: when release-plz releases pg-core at version X, the publish-wasm job publishes `@e4a/pg-wasm` at the same version X

From here, pg-core and pg-wasm stay in lockstep version-wise. release-plz bumps pg-core, and pg-wasm automatically gets published at the same version.

## After merge

Move the pg-pkg tag so the release-plz worktree has the workspace exclusion:
```bash
git tag -d pg-pkg-v0.3.0
git tag pg-pkg-v0.3.0 origin/main
git push origin --force refs/tags/pg-pkg-v0.3.0
```

Create a new bootstrap tag for pg-core at the new version:
```bash
git tag pg-core-v0.5.6
git push origin pg-core-v0.5.6
```