### PR TITLE
chore: bump pg-pkg to 0.5.6 to match existing Docker image versioning

### DIFF
--- a/pg-pkg/Cargo.toml
+++ b/pg-pkg/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 categories = ["cryptography"]
 repository = "https://github.com/encryption4all/postguard"
 name = "pg-pkg"
-version = "0.3.2"
+version = "0.5.6"
 
 [dependencies]
 actix-cors = "0.6.1"


### PR DESCRIPTION
## Summary

- Bumps pg-pkg from 0.3.2 to 0.5.6 (above the existing ghcr.io image tag 0.5.5)

## After merge

Move the pg-pkg tag and create a GitHub release:
```bash
git tag -d pg-pkg-v0.5.6 2>/dev/null
git tag pg-pkg-v0.5.6 origin/main
git push origin --force refs/tags/pg-pkg-v0.3.2
git push origin refs/tags/pg-pkg-v0.5.6
gh release create pg-pkg-v0.5.6 --title "pg-pkg-v0.5.6" --notes "Version sync with existing Docker images." --verify-tag
```