### PR TITLE
feat: support optional attributes in Yivi disclosure sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "pg-pkg"
-version = "0.5.7"
+version = "0.5.6"
 dependencies = [
  "actix-cors",
  "actix-http",

--- a/pg-cli/src/decrypt.rs
+++ b/pg-cli/src/decrypt.rs
@@ -7,7 +7,6 @@ use indicatif::{ProgressBar, ProgressStyle};
 use inquire::{Select, Text};
 use pg_core::artifacts::UserSecretKey;
 use pg_core::client::rust::stream::UnsealerStreamConfig;
-use pg_core::identity::Attribute;
 use std::fs::File;
 
 use pg_core::api::*;
@@ -64,9 +63,10 @@ pub async fn exec(dec_opts: DecOpts) {
         con: reconstructed_policy
             .con
             .iter()
-            .map(|attr| Attribute {
+            .map(|attr| DisclosureAttribute {
                 atype: attr.atype.clone(),
                 value: attr.value.clone(),
+                optional: false,
             })
             .collect(),
         validity: None,

--- a/pg-cli/src/encrypt.rs
+++ b/pg-cli/src/encrypt.rs
@@ -1,4 +1,4 @@
-use pg_core::api::{IrmaAuthRequest, SigningKeyRequest, SigningKeyResponse};
+use pg_core::api::{DisclosureAttribute, IrmaAuthRequest, SigningKeyRequest, SigningKeyResponse};
 use pg_core::client::rust::stream::SealerStreamConfig;
 use pg_core::client::Sealer;
 use pg_core::identity::{Attribute, Policy};
@@ -117,7 +117,14 @@ pub async fn exec(enc_opts: EncOpts) {
 
         let sd = client
             .request_start(&IrmaAuthRequest {
-                con: total_id,
+                con: total_id
+                    .into_iter()
+                    .map(|a| DisclosureAttribute {
+                        atype: a.atype,
+                        value: a.value,
+                        optional: false,
+                    })
+                    .collect(),
                 validity: None,
             })
             .await

--- a/pg-core/src/api.rs
+++ b/pg-core/src/api.rs
@@ -1,6 +1,7 @@
 //! Definitions of the PostGuard protocol REST API.
 
 use crate::{artifacts::SigningKeyExt, identity::Attribute};
+use alloc::string::String;
 use alloc::vec::Vec;
 use irma::{ProofStatus, SessionStatus};
 use serde::{Deserialize, Serialize};
@@ -16,11 +17,32 @@ pub struct Parameters<T> {
     pub public_key: T,
 }
 
+/// An attribute in a disclosure request, extending [`Attribute`] with an `optional` flag.
+///
+/// When `optional` is true, the PKG wraps this attribute in a disjunction with an empty
+/// first option, allowing the user to skip disclosing it in the Yivi app.
+///
+/// This type is only used in API requests (JSON), not in the binary wire format.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DisclosureAttribute {
+    /// Attribute type.
+    #[serde(rename = "t")]
+    pub atype: String,
+
+    /// Attribute value.
+    #[serde(rename = "v")]
+    pub value: Option<String>,
+
+    /// Whether this attribute is optional in the disclosure session.
+    #[serde(default, skip_serializing_if = "crate::util::is_false")]
+    pub optional: bool,
+}
+
 /// An authentication request for a IRMA identity.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IrmaAuthRequest {
-    /// The conjunction of [`Attribute`].
-    pub con: Vec<Attribute>,
+    /// The conjunction of attributes for the disclosure request.
+    pub con: Vec<DisclosureAttribute>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The validity (in seconds) of the JWT response.
     pub validity: Option<u64>,

--- a/pg-core/src/util.rs
+++ b/pg-core/src/util.rs
@@ -2,6 +2,11 @@ use crate::consts::*;
 use crate::error::Error;
 use alloc::string::String;
 
+/// Serde skip helper: returns true when the value is false.
+pub(crate) fn is_false(v: &bool) -> bool {
+    !v
+}
+
 pub(crate) fn open_ct<T>(x: subtle::CtOption<T>) -> Option<T> {
     if bool::from(x.is_some()) {
         Some(x.unwrap())

--- a/pg-pkg/src/handlers/start.rs
+++ b/pg-pkg/src/handlers/start.rs
@@ -56,18 +56,25 @@ pub async fn start(
         .con
         .iter()
         .map(|attr| {
-            vec![vec![AttributeRequest::Compound {
+            let ar = AttributeRequest::Compound {
                 attr_type: attr.atype.clone(),
                 value: attr.value.clone().filter(|v: &String| !v.is_empty()),
                 not_null: true,
-            }]]
+            };
+
+            if attr.optional {
+                // Empty first option means the user may skip this attribute
+                vec![vec![], vec![ar]]
+            } else {
+                vec![vec![ar]]
+            }
         })
         .collect();
 
     let dr = DisclosureRequestBuilder::new().add_discons(discons).build();
 
     log::debug!(
-        "decryption disclosure request: {}",
+        "disclosure request: {}",
         serde_json::to_string_pretty(&dr).unwrap_or_default()
     );
 


### PR DESCRIPTION
## Summary
- Adds an `optional` field to the `Attribute` struct in `pg-core`
- When `optional: true`, the PKG start handler wraps the attribute in a disjunction with an empty first option (`[[], [attr]]`), allowing users to skip it in the Yivi app
- Restores optional attribute functionality that was previously hardcoded in the removed `start_sign` endpoint

## Changes
- `pg-core/src/identity.rs`: Add `optional: bool` field to `Attribute` (defaults to `false`, skipped in serialization when false)
- `pg-core/src/util.rs`: Add `is_false` serde helper
- `pg-pkg/src/handlers/start.rs`: Check `optional` flag and build appropriate IRMA condiscon
- `pg-pkg/src/middleware/auth.rs`, `pg-cli/src/decrypt.rs`: Add `..Default::default()` to existing `Attribute` constructors

## Test plan
- [x] Verify `cargo check` passes
- [x] Send a request to `/v2/request/start` with `optional: true` on an attribute and verify the IRMA disclosure request includes the empty first option
- [x] Send a request without `optional` and verify backward-compatible behavior (all required)