### PR TITLE
feat: add pg-ffi crate for C ABI bindings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     name: Test workspace
     strategy:
       matrix:
-        workspace: [core, pkg, cli]
+        workspace: [core, pkg, cli, ffi]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
     name: Format workspace
     strategy:
       matrix:
-        workspace: [core, pkg, cli]
+        workspace: [core, pkg, cli, ffi]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -33,6 +33,7 @@ jobs:
       releases_created: ${{ steps.release-plz.outputs.releases_created }}
       pg_pkg_version: ${{ steps.parse.outputs.pg_pkg_version }}
       pg_core_version: ${{ steps.parse.outputs.pg_core_version }}
+      pg_ffi_version: ${{ steps.parse.outputs.pg_ffi_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -57,6 +58,8 @@ jobs:
           PG_CORE_VERSION=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "pg-core") | .version // empty')
           echo "pg_pkg_version=$PG_PKG_VERSION" >> "$GITHUB_OUTPUT"
           echo "pg_core_version=$PG_CORE_VERSION" >> "$GITHUB_OUTPUT"
+          PG_FFI_VERSION=$(echo "$RELEASES" | jq -r '.[] | select(.package_name == "pg-ffi") | .version // empty')
+          echo "pg_ffi_version=$PG_FFI_VERSION" >> "$GITHUB_OUTPUT"
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
@@ -223,6 +226,70 @@ jobs:
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
+
+  # ---------------------------------------------------------------------------
+  # pg-ffi: build native libraries for all platforms
+  # ---------------------------------------------------------------------------
+
+  # Build pg-ffi native libraries and upload as GitHub release assets.
+  build-ffi:
+    name: Build pg-ffi (${{ matrix.name }})
+    needs: release-plz-release
+    if: needs.release-plz-release.outputs.pg_ffi_version != ''
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+            name: linux-x64
+            lib: libpg_ffi.so
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            name: linux-arm64
+            lib: libpg_ffi.so
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            name: osx-arm64
+            lib: libpg_ffi.dylib
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            name: osx-x64
+            lib: libpg_ffi.dylib
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            name: win-x64
+            lib: pg_ffi.dll
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - name: Build pg-ffi
+        run: cargo build --release --target ${{ matrix.target }} -p pg-ffi
+      - name: Package artifact (unix)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p staging
+          cp target/${{ matrix.target }}/release/${{ matrix.lib }} staging/
+          cd staging && tar czf ../pg-ffi-${{ matrix.name }}.tar.gz *
+      - name: Package artifact (windows)
+        if: runner.os == 'Windows'
+        run: |
+          mkdir staging
+          cp target/${{ matrix.target }}/release/${{ matrix.lib }} staging/
+          Compress-Archive -Path staging/* -DestinationPath pg-ffi-${{ matrix.name }}.zip
+      - name: Upload to GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="pg-ffi-v${{ needs.release-plz-release.outputs.pg_ffi_version }}"
+          gh release upload "$TAG" pg-ffi-${{ matrix.name }}.* --clobber
 
   # ---------------------------------------------------------------------------
   # npm: publish pg-wasm to npmjs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,6 +2345,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pg-ffi"
+version = "0.1.0"
+dependencies = [
+ "ibe",
+ "pg-core",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "pg-pkg"
 version = "0.5.8"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["pg-core", "pg-cli", "pg-pkg"]
+members = ["pg-core", "pg-cli", "pg-pkg", "pg-ffi"]
 exclude = ["pg-wasm"]
 
 resolver = "2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ FROM chef AS planner
 COPY pg-core ./pg-core
 COPY pg-pkg  ./pg-pkg
 COPY pg-cli  ./pg-cli
+COPY pg-ffi  ./pg-ffi
 COPY pg-wasm ./pg-wasm
 COPY Cargo.toml Cargo.lock ./
 RUN cargo chef prepare --recipe-path recipe.json
@@ -27,6 +28,7 @@ RUN cargo chef cook --profile ${CARGO_PROFILE} --bin pg-pkg --recipe-path recipe
 COPY pg-core ./pg-core
 COPY pg-pkg  ./pg-pkg
 COPY pg-cli  ./pg-cli
+COPY pg-ffi  ./pg-ffi
 COPY pg-wasm ./pg-wasm
 COPY Cargo.toml Cargo.lock ./
 RUN cargo build --profile ${CARGO_PROFILE} --bin pg-pkg

--- a/pg-ffi/Cargo.toml
+++ b/pg-ffi/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pg-ffi"
+version = "0.1.0"
+edition = "2021"
+description = "C ABI wrapper around pg-core for PostGuard .NET SDK"
+
+[lib]
+crate-type = ["cdylib", "staticlib"]
+
+[dependencies]
+pg-core = { path = "../pg-core", features = ["rust"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+rand = "0.8"
+ibe = { version = "0.3.0", features = ["cgwkv", "mkem"] }

--- a/pg-ffi/build.sh
+++ b/pg-ffi/build.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "Building pg-ffi native library..."
+cargo build --release
+
+# Detect platform and copy to .NET runtimes directory
+UNAME_S=$(uname -s)
+UNAME_M=$(uname -m)
+
+if [ "$UNAME_S" = "Darwin" ]; then
+    LIB_EXT="dylib"
+    if [ "$UNAME_M" = "arm64" ]; then
+        RID="osx-arm64"
+    else
+        RID="osx-x64"
+    fi
+elif [ "$UNAME_S" = "Linux" ]; then
+    LIB_EXT="so"
+    if [ "$UNAME_M" = "aarch64" ]; then
+        RID="linux-arm64"
+    else
+        RID="linux-x64"
+    fi
+else
+    echo "Unsupported platform: $UNAME_S"
+    exit 1
+fi
+
+RELEASE_DIR="target/release"
+
+# If building as part of workspace, output goes to workspace root target/
+if [ -f "../Cargo.toml" ] && grep -q '\[workspace\]' "../Cargo.toml"; then
+    RELEASE_DIR="../target/release"
+fi
+
+echo "Built libpg_ffi.${LIB_EXT} at ${RELEASE_DIR}/"
+
+# Copy to postguard-dotnet runtimes if the repo exists alongside this one
+DOTNET_REPO="${PG_DOTNET_REPO:-../../postguard-dotnet}"
+if [ -d "$DOTNET_REPO/src/E4A.PostGuard" ]; then
+    DEST="${DOTNET_REPO}/src/E4A.PostGuard/runtimes/${RID}/native"
+    mkdir -p "$DEST"
+    cp "${RELEASE_DIR}/libpg_ffi.${LIB_EXT}" "$DEST/"
+    echo "Copied to ${DEST}/"
+else
+    echo "Set PG_DOTNET_REPO to copy the native library to postguard-dotnet"
+fi

--- a/pg-ffi/build.sh
+++ b/pg-ffi/build.sh
@@ -40,8 +40,8 @@ echo "Built libpg_ffi.${LIB_EXT} at ${RELEASE_DIR}/"
 
 # Copy to postguard-dotnet runtimes if the repo exists alongside this one
 DOTNET_REPO="${PG_DOTNET_REPO:-../../postguard-dotnet}"
-if [ -d "$DOTNET_REPO/src/E4A.PostGuard" ]; then
-    DEST="${DOTNET_REPO}/src/E4A.PostGuard/runtimes/${RID}/native"
+if [ -d "$DOTNET_REPO/src" ]; then
+    DEST="${DOTNET_REPO}/src/runtimes/${RID}/native"
     mkdir -p "$DEST"
     cp "${RELEASE_DIR}/libpg_ffi.${LIB_EXT}" "$DEST/"
     echo "Copied to ${DEST}/"

--- a/pg-ffi/src/lib.rs
+++ b/pg-ffi/src/lib.rs
@@ -1,0 +1,181 @@
+use std::cell::RefCell;
+use std::ffi::{c_char, CStr, CString};
+use std::slice;
+
+use ibe::kem::cgw_kv::CGWKV;
+use pg_core::artifacts::{PublicKey, SigningKeyExt};
+use pg_core::client::rust::SealerMemoryConfig;
+use pg_core::client::Sealer;
+use pg_core::identity::EncryptionPolicy;
+
+thread_local! {
+    static LAST_ERROR: RefCell<CString> = RefCell::new(CString::default());
+}
+
+fn set_last_error(msg: &str) {
+    LAST_ERROR.with(|e| {
+        *e.borrow_mut() = CString::new(msg).unwrap_or_default();
+    });
+}
+
+fn seal_impl(
+    mpk_json: &str,
+    policy_json: &str,
+    pub_sign_key_json: &str,
+    priv_sign_key_json: Option<&str>,
+    plaintext: &[u8],
+) -> Result<Vec<u8>, String> {
+    let mpk: PublicKey<CGWKV> =
+        serde_json::from_str(mpk_json).map_err(|e| format!("failed to parse MPK: {e}"))?;
+
+    let policy: EncryptionPolicy =
+        serde_json::from_str(policy_json).map_err(|e| format!("failed to parse policy: {e}"))?;
+
+    let pub_sign_key: SigningKeyExt = serde_json::from_str(pub_sign_key_json)
+        .map_err(|e| format!("failed to parse pubSignKey: {e}"))?;
+
+    let mut rng = rand::thread_rng();
+
+    let sealer = Sealer::<_, SealerMemoryConfig>::new(&mpk, &policy, &pub_sign_key, &mut rng)
+        .map_err(|e| format!("failed to create sealer: {e}"))?;
+
+    let sealer = if let Some(json) = priv_sign_key_json {
+        let priv_sign_key: SigningKeyExt =
+            serde_json::from_str(json).map_err(|e| format!("failed to parse privSignKey: {e}"))?;
+        sealer.with_priv_signing_key(priv_sign_key)
+    } else {
+        sealer
+    };
+
+    sealer
+        .seal(plaintext)
+        .map_err(|e| format!("seal failed: {e}"))
+}
+
+/// Seal (encrypt + sign) plaintext data using PostGuard IBE.
+///
+/// # Arguments
+/// - `mpk_json`: JSON string of the master public key (base64-encoded, e.g. `"\"<base64>\""`)
+/// - `policy_json`: JSON string of the encryption policy map
+/// - `pub_sign_key_json`: JSON string of the public signing key (`SigningKeyExt`)
+/// - `priv_sign_key_json`: JSON string of the private signing key, or null
+/// - `plaintext` + `plaintext_len`: input bytes to seal
+/// - `output` + `output_len`: out-parameters for sealed ciphertext (allocated by Rust)
+///
+/// Returns 0 on success, -1 on error. Call `pg_last_error()` for the error message.
+#[no_mangle]
+pub unsafe extern "C" fn pg_seal(
+    mpk_json: *const c_char,
+    policy_json: *const c_char,
+    pub_sign_key_json: *const c_char,
+    priv_sign_key_json: *const c_char,
+    plaintext: *const u8,
+    plaintext_len: usize,
+    output: *mut *mut u8,
+    output_len: *mut usize,
+) -> i32 {
+    let mpk_str = match CStr::from_ptr(mpk_json).to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in mpk_json: {e}"));
+            return -1;
+        }
+    };
+
+    let policy_str = match CStr::from_ptr(policy_json).to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in policy_json: {e}"));
+            return -1;
+        }
+    };
+
+    let pub_sign_str = match CStr::from_ptr(pub_sign_key_json).to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            set_last_error(&format!("invalid UTF-8 in pub_sign_key_json: {e}"));
+            return -1;
+        }
+    };
+
+    let priv_sign_str = if priv_sign_key_json.is_null() {
+        None
+    } else {
+        match CStr::from_ptr(priv_sign_key_json).to_str() {
+            Ok(s) => Some(s),
+            Err(e) => {
+                set_last_error(&format!("invalid UTF-8 in priv_sign_key_json: {e}"));
+                return -1;
+            }
+        }
+    };
+
+    let plain = if plaintext.is_null() || plaintext_len == 0 {
+        &[]
+    } else {
+        slice::from_raw_parts(plaintext, plaintext_len)
+    };
+
+    match seal_impl(mpk_str, policy_str, pub_sign_str, priv_sign_str, plain) {
+        Ok(sealed) => {
+            let len = sealed.len();
+            let boxed = sealed.into_boxed_slice();
+            let ptr = Box::into_raw(boxed) as *mut u8;
+            *output = ptr;
+            *output_len = len;
+            0
+        }
+        Err(msg) => {
+            set_last_error(&msg);
+            -1
+        }
+    }
+}
+
+/// Free memory allocated by `pg_seal`.
+#[no_mangle]
+pub unsafe extern "C" fn pg_free(ptr: *mut u8, len: usize) {
+    if !ptr.is_null() && len > 0 {
+        let _ = Box::from_raw(slice::from_raw_parts_mut(ptr, len));
+    }
+}
+
+/// Get the last error message. Returns a pointer to a null-terminated UTF-8 string.
+/// The pointer is valid until the next call to `pg_seal` on the same thread.
+#[no_mangle]
+pub extern "C" fn pg_last_error() -> *const c_char {
+    LAST_ERROR.with(|e| e.borrow().as_ptr())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn test_seal_invalid_mpk() {
+        let mpk = CString::new("\"invalid\"").unwrap();
+        let policy = CString::new("{}").unwrap();
+        let pub_sign = CString::new("{}").unwrap();
+        let mut output: *mut u8 = std::ptr::null_mut();
+        let mut output_len: usize = 0;
+
+        let result = unsafe {
+            pg_seal(
+                mpk.as_ptr(),
+                policy.as_ptr(),
+                pub_sign.as_ptr(),
+                std::ptr::null(),
+                std::ptr::null(),
+                0,
+                &mut output,
+                &mut output_len,
+            )
+        };
+
+        assert_eq!(result, -1);
+        let err = unsafe { CStr::from_ptr(pg_last_error()) };
+        let err_str = err.to_str().unwrap();
+        assert!(!err_str.is_empty());
+    }
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -16,3 +16,9 @@ publish = true
 name = "pg-pkg"
 publish = false
 git_only = true
+
+# pg-ffi: native binaries only, no crates.io publish
+[[package]]
+name = "pg-ffi"
+publish = false
+git_only = true


### PR DESCRIPTION
## Summary
- Adds `pg-ffi` crate to the workspace — a thin C ABI wrapper around pg-core's `Sealer`
- Exposes `pg_seal`, `pg_free`, `pg_last_error` for use via P/Invoke from the PostGuard .NET SDK ([postguard-dotnet](https://github.com/encryption4all/postguard-dotnet))
- Accepts JSON inputs (matching PKG API response formats) and returns sealed bytes

## Test plan
- [x] `cargo build --release -p pg-ffi` compiles
- [x] `cargo test -p pg-ffi` passes
- [x] End-to-end test via postguard-dotnet example app against staging