### PR TITLE
fix: add version and metadata to pg-ffi Cargo.toml

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -256,7 +256,7 @@ jobs:
             name: osx-arm64
             lib: libpg_ffi.dylib
           - target: x86_64-apple-darwin
-            runner: macos-13
+            runner: macos-latest
             name: osx-x64
             lib: libpg_ffi.dylib
           - target: x86_64-pc-windows-msvc
@@ -285,6 +285,7 @@ jobs:
           cp target/${{ matrix.target }}/release/${{ matrix.lib }} staging/
           Compress-Archive -Path staging/* -DestinationPath pg-ffi-${{ matrix.name }}.zip
       - name: Upload to GitHub release
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/pg-ffi/Cargo.toml
+++ b/pg-ffi/Cargo.toml
@@ -3,12 +3,14 @@ name = "pg-ffi"
 version = "0.1.0"
 edition = "2021"
 description = "C ABI wrapper around pg-core for PostGuard .NET SDK"
+license = "MIT"
+repository = "https://github.com/encryption4all/postguard"
 
 [lib]
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-pg-core = { path = "../pg-core", features = ["rust"] }
+pg-core = { path = "../pg-core", version = "0.5", features = ["rust"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rand = "0.8"


### PR DESCRIPTION
## Summary
- Adds `version = "0.5"` to the pg-core path dependency (required by `cargo package`)
- Adds `license` and `repository` fields to suppress release-plz warnings

Fixes the release-plz failure from #125.