### PR TITLE
ci: bump actions/checkout to v4 in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         workspace: [core, pkg, cli, ffi]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - if: ${{ matrix.workspace == 'core' }}
         run: cargo test --manifest-path pg-${{ matrix.workspace }}/Cargo.toml --features test,rust,stream
@@ -43,7 +43,7 @@ jobs:
         workspace: [core, pkg, cli, ffi]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo fmt --manifest-path pg-${{ matrix.workspace }}/Cargo.toml --all -- --check
 
@@ -62,7 +62,7 @@ jobs:
     env:
       WASM_BINDGEN_TEST_TIMEOUT: 120
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install
         run: cargo install wasm-pack
       - if: ${{ matrix.browser == 'firefox' }}


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from `@v3` to `@v4` in the `test` and `format` jobs
- Bumps `actions/checkout` from `@v2` to `@v4` in the `test-wasm-browsers` job
- Eliminates deprecated Node 16 runners; aligns with `delivery.yml` (already on `@v6`)

Closes #157.

This is the diff that was blocked from being pushed by the dobby agent because its GitHub App installation lacks the `workflows: write` permission. Pushed manually with a PAT carrying the `workflow` scope.

## Test plan
- [ ] CI is green on this branch (test, format, test-wasm-browsers)