### PR TITLE
chore: consume irmars from crates.io and bump reqwest to 0.12

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,17 +10,10 @@ ignore = [
     # ships a patched release.
     "RUSTSEC-2023-0071",
 
-    # RUSTSEC-2025-0134 — `rustls-pemfile 1.0.4` is unmaintained. Pulled in
-    # transitively via `reqwest 0.11.27` (which we use directly and through
-    # `irma 0.2.1`). The real fix is upgrading `reqwest` to 0.12 (and bumping
-    # `irma` to a version that uses it). Tracked in encryption4all/postguard#186.
-    # Drop this entry once the reqwest 0.12 migration lands.
-    "RUSTSEC-2025-0134",
-
-    # RUSTSEC-2026-0058 — `tokio-io 0.1.13` is unmaintained. Pulled in
-    # transitively by `futures-util`'s `compat` feature, which is enabled by
-    # `reqwest 0.11`, `actix-server`, and `sqlx-core`. No usage in our own
-    # code. Cleared by the same reqwest 0.12 / actix / sqlx upgrades tracked
-    # for the rustls-pemfile advisory above (postguard#186).
-    "RUSTSEC-2026-0058",
+    # RUSTSEC-2026-0058 — `tokio-io 0.1.13` is unmaintained. After the
+    # reqwest 0.12 migration the `reqwest 0.11` path is gone, but the
+    # advisory still surfaces through `futures-util`'s `compat` shim pulled
+    # in by `tower-http` (a `reqwest 0.12` transitive) and by `sqlx-*`.
+    # postguard does not call into the compat shim directly. Drop this
+    # entry once `tower-http` / `sqlx` stop using `futures-util` compat.
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.1",
  "brotli",
  "bytes 1.11.1",
@@ -54,8 +54,8 @@ dependencies = [
  "flate2",
  "foldhash",
  "futures-core",
- "h2",
- "http",
+ "h2 0.3.27",
+ "http 0.2.12",
  "httparse",
  "httpdate",
  "itoa",
@@ -91,7 +91,7 @@ checksum = "14f8c75c51892f18d9c46150c5ac7beb81c95f78c8b83a634d49f4ca32551fe7"
 dependencies = [
  "bytestring",
  "cfg-if",
- "http",
+ "http 0.2.12",
  "regex",
  "regex-lite",
  "serde",
@@ -209,7 +209,7 @@ checksum = "456348ed9dcd72a13a1f4a660449fafdecee9ac8205552e286809eb5b0b29bd3"
 dependencies = [
  "actix-utils",
  "actix-web",
- "base64 0.22.1",
+ "base64",
  "futures-core",
  "futures-util",
  "log",
@@ -385,6 +385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,12 +401,6 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1453,7 +1453,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes 1.11.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1549,13 +1568,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "0.4.6"
+name = "http"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes 1.11.1",
- "http",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes 1.11.1",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes 1.11.1",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1582,39 +1623,79 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
+ "atomic-waker",
  "bytes 1.11.1",
  "futures-channel",
  "futures-core",
- "futures-util",
- "h2",
- "http",
+ "h2 0.4.14",
+ "http 1.4.0",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
+name = "hyper-rustls"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes 1.11.1",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes 1.11.1",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.3",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1827,15 +1908,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "irma"
-version = "0.2.1"
+name = "irmars"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde914c868fcba263783b663b3ba195edcc17d1de3de23669cfd536efb6c6ad3"
+checksum = "57c4d99ff4871fb183e04c496a3c94bcd4078c60e04ac3e5b1f9daf0e6a36d21"
 dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -1912,7 +1993,7 @@ version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hmac",
@@ -2333,7 +2414,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -2361,7 +2442,7 @@ dependencies = [
  "futures 0.3.32",
  "indicatif",
  "inquire",
- "irma",
+ "irmars",
  "pg-core",
  "qrcode",
  "rand 0.8.6",
@@ -2385,7 +2466,7 @@ dependencies = [
  "futures-util",
  "ibe",
  "ibs",
- "irma",
+ "irmars",
  "js-sys",
  "rand 0.8.6",
  "serde",
@@ -2437,14 +2518,14 @@ dependencies = [
  "actix-web-httpauth",
  "arrayref",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bincode-next",
  "clap",
  "env_logger",
  "futures 0.3.32",
  "futures-util",
  "hex",
- "irma",
+ "irmars",
  "jsonwebtoken",
  "log",
  "pg-core",
@@ -2813,42 +2894,42 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "bytes 1.11.1",
  "encoding_rs",
  "futures-core",
- "futures-util",
- "h2",
- "http",
+ "h2 0.4.14",
+ "http 1.4.0",
  "http-body",
+ "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
- "ipnet",
+ "hyper-util",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
 ]
 
 [[package]]
@@ -2859,6 +2940,20 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2904,12 +2999,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "base64 0.21.7",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3247,7 +3366,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes 1.11.1",
  "crc",
  "crossbeam-queue",
@@ -3321,7 +3440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.1",
  "byteorder",
  "bytes 1.11.1",
@@ -3363,7 +3482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.1",
  "byteorder",
  "crc",
@@ -3459,9 +3578,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3476,20 +3598,20 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3679,6 +3801,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3702,6 +3834,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes 1.11.1",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -3828,6 +3999,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "unty-next"
@@ -4077,6 +4254,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4223,16 +4429,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/pg-cli/Cargo.toml
+++ b/pg-cli/Cargo.toml
@@ -19,11 +19,11 @@ futures = "0.3.27"
 rand = "0.8.4"
 clap = { version = "4", features = ["derive"] }
 qrcode = { version = "0.14", default-features = false }
-reqwest = { version = "0.11.14", default-features = false, features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "default-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.57" }
 tokio = { version = "1.26.0", features = ["full"] }
-irma = "0.2.1"
+irma = { package = "irmars", version = "0.2.2" }
 indicatif = "0.18"
 inquire = "0.6.0"
 anyhow = "1.0"

--- a/pg-core/Cargo.toml
+++ b/pg-core/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["cryptography"]
 [dependencies]
 ibe = { version = "0.3.0", features = ["cgwkv", "mkem"] }
 ibs =  "0.4.0"
-irma = "0.2.1"
+irma = { package = "irmars", version = "0.2.2" }
 rand = { version = "0.8", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/pg-pkg/Cargo.toml
+++ b/pg-pkg/Cargo.toml
@@ -23,9 +23,9 @@ async-trait = "0.1"
 sqlx = { version = "0.8", features = [ "postgres", "runtime-tokio", "tls-native-tls" ] }
 arrayref = "0.3.5"
 futures-util = "0.3"
-irma = "0.2.1"
+irma = { package = "irmars", version = "0.2.2" }
 rand = "0.8"
-reqwest = "0.11.10"
+reqwest = "0.12"
 serde = "1.0"
 serde_json = "1.0.68"
 subtle = "2.1.1"


### PR DESCRIPTION
## Summary
Switches every pg-* crate from the abandoned upstream `irma 0.2.1` (`tweedegolf/irmars`, dormant since 2021) to the encryption4all fork published on crates.io as **`irmars 0.2.2`**. Uses the Cargo \`package = \"irmars\"\` rename so existing \`use irma::...\` call sites are unchanged.

\`irmars 0.2.2\` already depends on \`reqwest ^0.12\` and \`thiserror ^2.0\`, so this single dep flip also completes the reqwest 0.12 migration that #186 tracks.

## Relation to existing work
- **Supersedes #188.** That PR vendored an `irma 0.2.1` source copy at `./irma/` and patched its `reqwest` dep locally — a workaround for the absence of a published reqwest-0.12 release. With the encryption4all fork now on crates.io, the vendored copy is no longer needed; the result is the same dependency graph with ~1300 fewer lines of code in this repo.
- **Closes #186** — the underlying audit-allowlist tracking issue.

## Changes

| File | Change |
|---|---|
| `pg-core/Cargo.toml` | `irma = "0.2.1"` -> `irma = { package = "irmars", version = "0.2.2" }` |
| `pg-cli/Cargo.toml` | `irma` rename as above; `reqwest = "0.11.14"` -> `"0.12"` (kept `default-features = false` with `json` + `default-tls`) |
| `pg-pkg/Cargo.toml` | `irma` rename as above; `reqwest = "0.11.10"` -> `"0.12"` |
| `.cargo/audit.toml` | `RUSTSEC-2025-0134` (rustls-pemfile) entry removed. `RUSTSEC-2026-0058` (tokio-io) retained with an updated comment — see [Caveat](#caveat). |
| `Cargo.lock` | Regenerated. |

## Caveat: tokio-io advisory partially cleared

The reqwest 0.11 path is gone, but `RUSTSEC-2026-0058` (`tokio-io 0.1.13`) still surfaces through `futures-util`'s `compat` feature pulled in by `tower-http` (a `reqwest 0.12` transitive) and by `sqlx-*`. postguard does not call the compat shim directly; the allowlist entry is retained with a revised comment. Clearing it needs a `tower-http` / `sqlx` upstream fix.

## Verification

- `cargo build --workspace` — clean.
- `cargo test --manifest-path pg-core/Cargo.toml --features test,rust,stream` — passed.
- `cargo test --manifest-path pg-cli/Cargo.toml --all-features` — 7 passed.
- `cargo test --manifest-path pg-pkg/Cargo.toml --all-features` — 30 passed.
- `cargo test --manifest-path pg-ffi/Cargo.toml --all-features` — 1 passed.
- `cargo build --profile edge --bin pg-pkg` — clean (matches Docker CI invocation).
- pg-wasm is excluded from the workspace and doesn't depend on `irma` or `reqwest`, so no change there.

## Reviewer quickstart

```
git fetch origin && git checkout chore/use-irmars-from-crates-io
cargo build --workspace
cargo audit
```

## Once this merges

Please close **PR #188** ("chore: migrate off reqwest 0.11 to clear unmaintained transitives") as superseded — GitHub doesn't auto-close PRs from a `Supersedes` reference, only issues.