### PR TITLE
feat(api): accept Yivi condiscon in IrmaAuthRequest

### DIFF
--- a/pg-cli/src/decrypt.rs
+++ b/pg-cli/src/decrypt.rs
@@ -74,10 +74,12 @@ pub async fn exec(dec_opts: DecOpts) -> Result<()> {
         con: reconstructed_policy
             .con
             .iter()
-            .map(|attr| DisclosureAttribute {
-                atype: attr.atype.clone(),
-                value: attr.value.clone(),
-                optional: false,
+            .map(|attr| {
+                ConItem::Single(DisclosureAttribute {
+                    atype: attr.atype.clone(),
+                    value: attr.value.clone(),
+                    optional: false,
+                })
             })
             .collect(),
         validity: None,

--- a/pg-cli/src/encrypt.rs
+++ b/pg-cli/src/encrypt.rs
@@ -1,4 +1,6 @@
-use pg_core::api::{DisclosureAttribute, IrmaAuthRequest, SigningKeyRequest, SigningKeyResponse};
+use pg_core::api::{
+    ConItem, DisclosureAttribute, IrmaAuthRequest, SigningKeyRequest, SigningKeyResponse,
+};
 use pg_core::client::rust::stream::SealerStreamConfig;
 use pg_core::client::Sealer;
 use pg_core::identity::{Attribute, Policy};
@@ -126,10 +128,12 @@ pub async fn exec(enc_opts: EncOpts) -> Result<()> {
             .request_start(&IrmaAuthRequest {
                 con: total_id
                     .into_iter()
-                    .map(|a| DisclosureAttribute {
-                        atype: a.atype,
-                        value: a.value,
-                        optional: false,
+                    .map(|a| {
+                        ConItem::Single(DisclosureAttribute {
+                            atype: a.atype,
+                            value: a.value,
+                            optional: false,
+                        })
                     })
                     .collect(),
                 validity: None,

--- a/pg-core/src/api.rs
+++ b/pg-core/src/api.rs
@@ -39,10 +39,15 @@ pub struct DisclosureAttribute {
 }
 
 /// An authentication request for a IRMA identity.
+///
+/// Each entry in `con` is either a single attribute ([`ConItem::Single`]) or
+/// a Yivi disjunction-of-conjunctions ([`ConItem::Discon`]). The legacy flat
+/// `[{t,v?,optional?}, ...]` JSON shape still deserialises, because
+/// `ConItem` is `#[serde(untagged)]`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IrmaAuthRequest {
-    /// The conjunction of attributes for the disclosure request.
-    pub con: Vec<DisclosureAttribute>,
+    /// The conjunction of attributes (or disjunctions) for the disclosure request.
+    pub con: Vec<ConItem>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The validity (in seconds) of the JWT response.
     pub validity: Option<u64>,
@@ -76,6 +81,23 @@ pub struct SigningKeyRequest {
     pub priv_sign_id: Option<Vec<Attribute>>,
 }
 
+/// One entry inside [`IrmaAuthRequest::con`].
+///
+/// Backwards compatible widening: existing callers post a JSON array of
+/// `{t,v?,optional?}` objects, which deserialize into [`ConItem::Single`].
+/// New callers may post an inner JSON array-of-arrays for a Yivi
+/// disjunction-of-conjunctions (`OR` of `AND`), which deserializes into
+/// [`ConItem::Discon`]. An empty inner conjunction marks the discon as
+/// optional per Yivi convention.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum ConItem {
+    /// A single attribute, optionally marked `optional: true`.
+    Single(DisclosureAttribute),
+    /// A disjunction of conjunctions of attributes.
+    Discon(Vec<Vec<DisclosureAttribute>>),
+}
+
 /// The signing key response from the Private Key Generator (PKG).
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -95,4 +117,69 @@ pub struct SigningKeyResponse {
     /// This private signing key.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub priv_sign_key: Option<SigningKeyExt>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// New shape: a JSON `con` array containing a discon (nested array)
+    /// must deserialize into [`ConItem::Discon`] alongside any [`ConItem::Single`] entries.
+    #[test]
+    fn irma_auth_request_accepts_discon_entry() {
+        let body = r#"{
+            "con": [
+                { "t": "pbdf.sidn-pbdf.email.email" },
+                [
+                    [ { "t": "pbdf.gemeente.personalData.fullname" } ],
+                    [
+                        { "t": "pbdf.pbdf.passport.firstName" },
+                        { "t": "pbdf.pbdf.passport.lastName" }
+                    ]
+                ]
+            ]
+        }"#;
+
+        let req: IrmaAuthRequest =
+            serde_json::from_str(body).expect("body should parse with a discon entry");
+
+        assert_eq!(req.con.len(), 2);
+        match &req.con[0] {
+            ConItem::Single(a) => assert_eq!(a.atype, "pbdf.sidn-pbdf.email.email"),
+            other => panic!("expected Single, got {:?}", other),
+        }
+        match &req.con[1] {
+            ConItem::Discon(d) => {
+                assert_eq!(d.len(), 2, "two alternatives");
+                assert_eq!(d[0].len(), 1, "first alt: one attr");
+                assert_eq!(d[1].len(), 2, "second alt: firstName+lastName");
+                assert_eq!(d[0][0].atype, "pbdf.gemeente.personalData.fullname");
+                assert_eq!(d[1][0].atype, "pbdf.pbdf.passport.firstName");
+                assert_eq!(d[1][1].atype, "pbdf.pbdf.passport.lastName");
+            }
+            other => panic!("expected Discon, got {:?}", other),
+        }
+    }
+
+    /// Backwards-compat: an old-style flat `con` of `{t,v?,optional?}` objects
+    /// must still parse into [`ConItem::Single`] variants.
+    #[test]
+    fn irma_auth_request_keeps_parsing_flat_con() {
+        let body = r#"{
+            "con": [
+                { "t": "pbdf.sidn-pbdf.email.email" },
+                { "t": "pbdf.gemeente.personalData.fullname", "optional": true }
+            ]
+        }"#;
+
+        let req: IrmaAuthRequest = serde_json::from_str(body).expect("legacy flat con must parse");
+
+        assert_eq!(req.con.len(), 2);
+        for item in &req.con {
+            assert!(matches!(item, ConItem::Single(_)), "all entries Single");
+        }
+        if let ConItem::Single(a) = &req.con[1] {
+            assert!(a.optional, "optional flag preserved");
+        }
+    }
 }

--- a/pg-pkg/src/handlers/start.rs
+++ b/pg-pkg/src/handlers/start.rs
@@ -2,7 +2,7 @@ use crate::util::{IrmaToken, IrmaUrl};
 use crate::Error;
 use actix_web::{web::Data, web::Json, HttpResponse};
 use irma::*;
-use pg_core::api::IrmaAuthRequest;
+use pg_core::api::{ConItem, DisclosureAttribute, IrmaAuthRequest};
 
 /// Maximum allowed validity (in seconds) of a JWT (1 day).
 const MAX_VALIDITY: u64 = 60 * 60 * 24;
@@ -43,6 +43,34 @@ async fn create_irma_session(
     Ok(HttpResponse::Ok().json(session))
 }
 
+fn attr_to_request(attr: &DisclosureAttribute) -> AttributeRequest {
+    AttributeRequest::Compound {
+        attr_type: attr.atype.clone(),
+        value: attr.value.clone().filter(|v: &String| !v.is_empty()),
+        not_null: true,
+    }
+}
+
+/// Map one top-level `con` entry to the Yivi discon shape
+/// (`Vec<Vec<AttributeRequest>>` — OR of ANDs).
+fn con_item_to_discon(item: &ConItem) -> Vec<Vec<AttributeRequest>> {
+    match item {
+        ConItem::Single(attr) => {
+            let ar = attr_to_request(attr);
+            if attr.optional {
+                // Empty first option lets the user skip this attribute.
+                vec![vec![], vec![ar]]
+            } else {
+                vec![vec![ar]]
+            }
+        }
+        ConItem::Discon(disjuncts) => disjuncts
+            .iter()
+            .map(|conj| conj.iter().map(attr_to_request).collect())
+            .collect(),
+    }
+}
+
 // Starts a Yivi disclosure session.
 // Builds a disclosure request for every attribute in the request's policy.
 pub async fn start(
@@ -52,24 +80,7 @@ pub async fn start(
 ) -> Result<HttpResponse, Error> {
     let kr = value.into_inner();
 
-    let discons: Vec<Vec<Vec<AttributeRequest>>> = kr
-        .con
-        .iter()
-        .map(|attr| {
-            let ar = AttributeRequest::Compound {
-                attr_type: attr.atype.clone(),
-                value: attr.value.clone().filter(|v: &String| !v.is_empty()),
-                not_null: true,
-            };
-
-            if attr.optional {
-                // Empty first option means the user may skip this attribute
-                vec![vec![], vec![ar]]
-            } else {
-                vec![vec![ar]]
-            }
-        })
-        .collect();
+    let discons: Vec<Vec<Vec<AttributeRequest>>> = kr.con.iter().map(con_item_to_discon).collect();
 
     let dr = DisclosureRequestBuilder::new().add_discons(discons).build();
 
@@ -79,4 +90,76 @@ pub async fn start(
     );
 
     create_irma_session(&url, &irma_token, dr, kr.validity).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn attr(t: &str) -> DisclosureAttribute {
+        DisclosureAttribute {
+            atype: t.to_string(),
+            value: None,
+            optional: false,
+        }
+    }
+
+    fn extract_atype(ar: &AttributeRequest) -> &str {
+        match ar {
+            AttributeRequest::Compound { attr_type, .. } => attr_type.as_str(),
+            AttributeRequest::Simple(s) => s.as_str(),
+        }
+    }
+
+    #[test]
+    fn single_required_maps_to_one_inner_conjunction() {
+        let item = ConItem::Single(attr("pbdf.sidn-pbdf.email.email"));
+        let dis = con_item_to_discon(&item);
+        assert_eq!(dis.len(), 1, "required: one option");
+        assert_eq!(dis[0].len(), 1, "one attribute");
+        assert_eq!(extract_atype(&dis[0][0]), "pbdf.sidn-pbdf.email.email");
+    }
+
+    #[test]
+    fn single_optional_prepends_empty_alternative() {
+        let mut a = attr("pbdf.sidn-pbdf.mobilenumber.mobilenumber");
+        a.optional = true;
+        let item = ConItem::Single(a);
+        let dis = con_item_to_discon(&item);
+        assert_eq!(dis.len(), 2, "optional: empty alt + actual");
+        assert!(dis[0].is_empty(), "empty alternative first");
+        assert_eq!(dis[1].len(), 1);
+    }
+
+    #[test]
+    fn discon_maps_each_inner_conjunction_through() {
+        // Models the name disjunction: gemeente fullname OR passport firstName+lastName.
+        let item = ConItem::Discon(vec![
+            vec![attr("pbdf.gemeente.personalData.fullname")],
+            vec![
+                attr("pbdf.pbdf.passport.firstName"),
+                attr("pbdf.pbdf.passport.lastName"),
+            ],
+        ]);
+        let dis = con_item_to_discon(&item);
+        assert_eq!(dis.len(), 2, "two alternatives");
+        assert_eq!(dis[0].len(), 1, "first: fullname only");
+        assert_eq!(dis[1].len(), 2, "second: firstName + lastName");
+        assert_eq!(
+            extract_atype(&dis[0][0]),
+            "pbdf.gemeente.personalData.fullname"
+        );
+        assert_eq!(extract_atype(&dis[1][0]), "pbdf.pbdf.passport.firstName");
+        assert_eq!(extract_atype(&dis[1][1]), "pbdf.pbdf.passport.lastName");
+    }
+
+    #[test]
+    fn discon_with_empty_alternative_is_passed_through() {
+        // Yivi-native way to mark a whole discon as optional.
+        let item = ConItem::Discon(vec![vec![], vec![attr("pbdf.foo.bar.baz")]]);
+        let dis = con_item_to_discon(&item);
+        assert_eq!(dis.len(), 2);
+        assert!(dis[0].is_empty(), "empty alternative preserved");
+        assert_eq!(dis[1].len(), 1);
+    }
 }


### PR DESCRIPTION
## Summary

- `pg-core::api`: add untagged `ConItem` enum (`Single` | `Discon`); widen `IrmaAuthRequest.con` to `Vec<ConItem>`.
- `pg-pkg::handlers::start`: extract `con_item_to_discon`; map `Single` as today, `Discon` straight through to the Yivi `DisclosureRequest`.
- `pg-cli`: callers wrap into `ConItem::Single` (no behaviour change).

Backwards compatible at the HTTP boundary — legacy `{"con":[{t,v?,optional?}, ...]}` bodies still parse, because `ConItem` is `#[serde(untagged)]`.

## Why

postguard-website needs to accept a sender name from one of four Yivi credentials — gemeente `personalData.fullname` **or** `firstName`+`lastName` from `pbdf.pbdf.passport` / `idcard` / `drivinglicence`. The current flat `con` shape can only express a conjunction with per-attribute `optional` flags; it cannot express OR across credentials. The PostGuard hand-off doc §2.4 already treats Yivi condiscon as the canonical input that Algorithm 3 normalises into a sorted conjunction — this PR just exposes that shape at the HTTP boundary. No protocol-layer changes (header, wire format, IBE/IBS identities).

## Test plan

- [x] `cargo test -p pg-core --features test` — 43/43.
- [x] `cargo test -p pg-pkg` — 34/34 (4 new tests on `con_item_to_discon` + 30 prior).
- [ ] Manual smoke against a running dev compose stack: POST a body with one `Single` and one nested `Discon` entry to `/v2/request/start`; check the `disclosure request:` log line (`start.rs:77`) shows the expected nested `discon`.

## Companion PRs

- `postguard-js` — exposes the discon shape through `pg.sign.yivi({ attributes })`.
- `cryptify` — extends `sender_display` to render `firstName + lastName` from the three ID credentials.
- `postguard-website` — uses the new condiscon to make the name requirement satisfiable from any of the four credentials (supersedes #239 in that repo).