### PR TITLE
ci: strip dead default-module-path branch from pg-wasm web build

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -324,6 +324,31 @@ jobs:
       - name: Build pg-wasm (web)
         run: wasm-pack build --release -d pkg/web --out-name index --scope e4a --target web ./pg-wasm
 
+      # wasm-bindgen's `--target web` output emits a default-module-path branch
+      # (`module_or_path = new URL('index_bg.wasm', import.meta.url)`) that
+      # webpack 5 statically resolves as an asset import at build time even when
+      # the branch is unreachable, breaking consumers that always pass
+      # `module_or_path` explicitly (e.g. @e4a/pg-js). wasm-pack does not expose
+      # wasm-bindgen's `--omit-default-module-path` flag, so we strip the branch
+      # from the generated index.js after the build. Fails loudly if the pattern
+      # is gone so a future wasm-bindgen change can't silently no-op the strip.
+      # The bundler target is unaffected (no init function). See #153.
+      - name: Strip default-module-path branch from web target (#153)
+        run: |
+          node -e "
+          const fs = require('fs');
+          const p = 'pg-wasm/pkg/web/index.js';
+          const re = /\n\s*if \([^)]*module_or_path[^)]*\) \{\s*module_or_path = new URL\('index_bg\.wasm', import\.meta\.url\);\s*\}\n/;
+          const src = fs.readFileSync(p, 'utf8');
+          const out = src.replace(re, '\n');
+          if (out === src) {
+            console.error('Strip pattern not found in ' + p + '; wasm-bindgen output may have changed. See #153.');
+            process.exit(1);
+          }
+          fs.writeFileSync(p, out);
+          console.log('Stripped default-module-path branch from ' + p);
+          "
+
       - name: Assemble package
         working-directory: pg-wasm/pkg
         run: |


### PR DESCRIPTION
## Summary

The `@e4a/pg-wasm` web target generated by `wasm-pack build --target web` ships an unreachable default-value branch in `__wbg_init`:

```js
if (module_or_path === undefined) {
    module_or_path = new URL('index_bg.wasm', import.meta.url);
}
```

Webpack 5 statically analyzes `new URL("...", import.meta.url)` as an asset import and tries to resolve `index_bg.wasm` at build time — even though the branch never fires for callers that always pass `module_or_path` explicitly (e.g. `@e4a/pg-js`, which inlines the WASM as base64). Downstream consumers therefore hit `Module not found: Can't resolve 'index_bg.wasm'`.

`wasm-pack` does not expose wasm-bindgen's `--omit-default-module-path` flag, so this PR adds a post-build step to `delivery.yml`'s `publish-wasm` job that strips the branch from the generated `pg-wasm/pkg/web/index.js`. The strip:

- Matches the assignment block by pattern (not line numbers), with a flexible `if` condition so a wasm-bindgen version change to e.g. `typeof module_or_path === 'undefined'` still matches.
- **Fails loudly** (`exit 1`) if the pattern is gone, so a future wasm-bindgen change can't silently no-op the strip and ship the regression again.

The **bundler target is unaffected** — it emits `import * as wasm from "./index_bg.wasm"` with no `__wbg_init` function and no `new URL(...)` branch — so no strip is needed there (this corrects fix-option 2 in the issue body).

## Verification

Built the web target locally with `wasm-pack 0.14.0` and confirmed against the real generated output:

- The dead branch is present at `pg-wasm/pkg/web/index.js` before stripping.
- The exact `node` script from this PR removes the 3-line block, leaving zero `index_bg.wasm` references.
- The remaining `__wbg_init` flow is intact — control passes straight into the `typeof module_or_path === 'string' || ... instanceof Request || ... instanceof URL` path that fires when a caller passes `module_or_path` explicitly.
- `node --check` passes on the stripped file.

Behavior change: a caller that invokes `init()` with no argument now gets a runtime error at instantiate time instead of a webpack build-time error — exactly what `--omit-default-module-path` produces. All current consumers pass `module_or_path`, so they are unaffected.

## Downstream

Once a new `@e4a/pg-wasm` ships with this fix, `@e4a/pg-js` only needs a dep bump + republish, and the `parser: { url: false }` webpack workaround in downstream consumers can be removed.

Fixes #153