### PR TITLE
style(pg-cli): drop useless borrow in decrypt eprintln (clippy)

### DIFF
--- a/pg-cli/src/decrypt.rs
+++ b/pg-cli/src/decrypt.rs
@@ -85,7 +85,7 @@ pub async fn exec(dec_opts: DecOpts) -> Result<()> {
         validity: None,
     };
 
-    eprintln!("Requesting key for {:?}", &keyrequest);
+    eprintln!("Requesting key for {:?}", keyrequest);
 
     let sd: irma::SessionData = client
         .request_start(&keyrequest)


### PR DESCRIPTION
Fixes the pre-existing `Clippy workspace (cli)` failure on `main`.

`cargo clippy --manifest-path pg-cli/Cargo.toml --all-targets --all-features -- -D warnings`
(current stable) flags `&keyrequest` at `pg-cli/src/decrypt.rs:88` as
`clippy::useless_borrows_in_formatting`. Because the clippy matrix uses
fail-fast, this one lint also cancels the `core`/`ffi`/`pkg` shards, so it blocks
every PR from going green — not just this one.

The `{:?}` formatter borrows its argument internally and `keyrequest` is still
used on the next line, so removing the `&` is a no-op behavior change.

Verified locally: the exact CI command now exits 0.