### PR TITLE
ci: unignore the tracked JWT rotation fixtures so release-plz runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,11 @@ pkg_ibs.sec
 # `--manifest-path pg-wasm/Cargo.toml` resolves it on its own and writes a
 # lockfile next to the manifest. The repo does not track it.
 pg-wasm/Cargo.lock
+
+# #241's JWT-rotation fixtures are committed, and `*.pem` above would otherwise
+# leave them tracked *and* ignored. release-plz refuses to run against a repo in
+# that state, which took delivery.yml's `Release-plz PR` job down (#273); the
+# `Release-plz release` job is separate and kept working, so nothing looked
+# broken. `git ls-files -ci --exclude-standard` lists what is in that state, and
+# must stay empty.
+!pg-pkg/testdata/jwt_rotation/*.pem


### PR DESCRIPTION
Root `.gitignore`'s `*.pem` matches the four fixtures #241 committed under `pg-pkg/testdata/jwt_rotation/`, leaving them tracked *and* ignored. release-plz refuses to run against a repo in that state:

```
ERROR failed to update packages
  1: the working directory of this project has uncommitted changes. If these files
     are both committed and in .gitignore, either delete them or remove them from
     .gitignore.
     ["pg-pkg/testdata/jwt_rotation/priv_a.pem", …]
```

So `delivery.yml`'s `Release-plz PR` job has failed on every push to `main` since #241 landed on 2026-07-16. Twelve runs, most recently [30448113952](https://github.com/encryption4all/postguard/actions/runs/30448113952). `Release-plz release` is a separate job and was unaffected, which is why releases kept tagging and nothing looked broken.

The visible damage is PR #187 (`chore: release`), still open and last updated 2026-07-16. It is missing the version bumps and changelog entries for everything merged after that date, including the wire-compat gate, COMPATIBILITY.md, cargo-semver-checks and the oasdiff gate.

## The change

One negation, scoped to that one directory so no other `.pem` is unignored:

```gitignore
!pg-pkg/testdata/jwt_rotation/*.pem
```

The fixtures are throwaway RSA keypairs for `middleware::auth::tests::test_jwt_key_refresh_on_rotation` and are already in history. This changes how git treats them, not what is committed.

## Verification

`git ls-files -ci --exclude-standard` is the check: it lists files that are both tracked and ignored, and on `main` it returns those four. On this branch it returns nothing, and `release-plz update` gets past the working-directory check and starts resolving versions.

Both were run locally against a clone of this branch and a control clone of `main`.

## Not in this PR

Nothing in CI reports this class, so the same mistake can land again the same way. A step that fails when `git ls-files -ci --exclude-standard` is non-empty would have caught it in #241's own PR. Left out here to keep the fix reviewable on its own; noted in #273.

Closes #273
