### PR TITLE
fix(cryptify): release the stranded security fixes as 0.1.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1082,7 +1082,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cryptify"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "askama",
  "chrono",

--- a/cryptify/CHANGELOG.md
+++ b/cryptify/CHANGELOG.md
@@ -7,10 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28] - 2026-07-31
+
+First release since the crate moved into the postguard workspace
+(encryption4all/postguard#255), covering everything merged in the cryptify repo
+after v0.1.27 (2026-05-16).
+
 ### Security
 
 - require a validated API key on `GET /usage` and reject unauthenticated callers with 401 (GHSA-5rhx-xgvv-h78h)
 - compare `cryptify_token` values in constant time, matching the recovery-token path
+- bump lettre 0.11.21 -> 0.11.22 (RUSTSEC-2026-0141)
+
+### Added
+
+- expose Prometheus `/metrics` endpoint for usage dashboards
+- *(metrics)* require a bearer token on `/metrics` when configured
+- *(metrics)* pre-seed known channels at zero on startup
+- *(metrics)* capture `X-POSTGUARD-CLIENT-VERSION` client identity
+- *(email)* staging-only `/staging/preview/<uuid>` + shared render API
+- *(email)* replace unicode checkmark with inline PNG image
+- *(email)* remove circle around signer-verified checkmark
+- add `GET /email-template` endpoint keyed on API key
+- persist rolling-quota usage to SQLite (`usage_db`)
+- configurable email attribute type for the finalize sender check
+
+### Fixed
+
+- *(email)* address encryption4all/postguard#197 deliverability + show disclosed signer name
+- *(email)* larger, selectable download-link code block in recipient email
+- *(cors)* allow Office add-in origins (addin.postguard.eu + localhost:3000) and DELETE method
+- *(cors)* allow `X-Cryptify-Source` in browser preflights
+- return generic body from 5xx responses, log detail server-side
+- retry the startup verifying-key fetch instead of panicking
+
+### Other
+
+- add the oasdiff breaking-change gate, and pin its severity settings with a test
+- true up `api-description.yaml` with the mounted routes
+- add semantic PR title check workflow
+- replace `pkg_url` with https://pkg.postguard.eu/
+- bump pg-core 0.6.0 -> 0.6.1
+- remove unused `qrcode`, `strum`, `strum_macros` and `irma` dependencies
+- update dependencies
 
 ## [0.1.27](https://github.com/encryption4all/cryptify/compare/v0.1.26...v0.1.27) - 2026-05-16
 

--- a/cryptify/Cargo.toml
+++ b/cryptify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptify"
-version = "0.1.27"
+version = "0.1.28"
 authors = ["David Venhoek <david@tweedegolf.com>"]
 edition = "2021"
 repository = "https://github.com/encryption4all/cryptify"


### PR DESCRIPTION
cryptify's `CHANGELOG.md` carried two hand-written bullets under `## [Unreleased]`, one of them citing **GHSA-5rhx-xgvv-h78h**:

```
## [Unreleased]

### Security

- require a validated API key on `GET /usage` and reject unauthenticated callers with 401 (GHSA-5rhx-xgvv-h78h)
- compare `cryptify_token` values in constant time, matching the recovery-token path
```

release-plz inserts each new version section *below* that heading, so bullets written there are never folded into the release that follows. They sit above the newest version, undated, indefinitely. CLAUDE.md documents this trap; these two were already in it.

Both describe `8531b28` (2026-07-06). I checked the code rather than trusting the note: `cryptify_tokens_match` uses `subtle::ConstantTimeEq`, and there is a `usage_rejects_unauthenticated_request` test. The fixes are real and merged.

## They were not alone

cryptify's last release is **v0.1.27, 2026-05-16**, and **31 commits** have merged since. The `[Unreleased]` section documented two of them. Also sitting unreleased for two and a half months:

- `lettre` 0.11.21 → 0.11.22 (**RUSTSEC-2026-0141**)
- a bearer token on `/metrics` when configured
- generic 5xx response bodies, with detail logged server-side instead of returned

## What this does

Writes a dated `0.1.28` section covering the real backlog, derived from the commit subjects rather than hand-summarised, and bumps `cryptify/Cargo.toml` so release-plz's `release` job tags it.

**Merging this cuts cryptify 0.1.28** and publishes the advisory fix in a dated release note.

## On hand-bumping the version

Normally release-plz owns version numbers and a PR should not set them. It cannot do it here. release-plz decides a package changed by looking for commits touching `cryptify/`, and the imported history carries root-level paths (`src/main.rs`, not `cryptify/src/main.rs`), so it sees no cryptify changes and proposes no bump. #278 confirms this: it touches pg-cli and pg-pkg only, both before and after the history graft.

So without a manual bump, nothing ever releases these. After this lands, release-plz has a `cryptify-v0.1.28` tag to measure from and normal service resumes.

## Verification

`cargo test --manifest-path cryptify/Cargo.toml --all-targets` → 157 passed. Workspace resolves; the only lockfile change is cryptify's own version.
