### PR TITLE
fix(compat): close reader-list coverage gaps for crates.io rows

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -108,7 +108,7 @@ npm @e4a/pg-js 2.3.3 1.11.0
 nuget E4A.PostGuard 0.6.0
 ```
 
-Checked against the registries on 2026-07-27. A producer publishing a new
+Checked against the registries on 2026-08-06. A producer publishing a new
 version moves a pin; a line leaves the list only through the deprecation
 process below. The npm version of `@e4a/pg-wasm` tracks the released `pg-core`
 version rather than `pg-wasm/Cargo.toml`, so read that pin from npm and not

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -92,13 +92,13 @@ exact release rather than building against the latest one
 
 The window above resolved to concrete versions: the highest published patch of
 each line in the window. This is the list the compat gates install and run as
-readers, but they do not yet cover it evenly: `wire-compat-js` enforces the npm
-rows (`pg-compat-js/test/manifest.test.mjs` machine-reads the fenced block
-below, so a drifted npm row goes red — keep that block as rows, not prose),
-while `wire-compat-rust` covers only the one crates.io version pinned in
-`pg-compat/Cargo.toml`. Nothing reads the crates.io rows themselves, so a row
-there can drift from that manifest unnoticed; see the coverage note below the
-block.
+readers. `wire-compat-js` enforces the npm rows
+(`pg-compat-js/test/manifest.test.mjs` machine-reads the fenced block below,
+so a drifted npm row goes red), and `wire-compat-rust` now enforces both
+crates.io versions pinned in `pg-compat/Cargo.toml`
+(`pg-compat/tests/support_window.rs` reads the same block and fails when it
+drifts from `pg-compat`'s `readers()`) — keep that block as rows, not prose,
+in either direction.
 
 ```
 # <registry> <package> <versions...>
@@ -134,12 +134,13 @@ npm lines are also spelled out in `pg-compat-js/src/readers.mjs`, whose
 `test/manifest.test.mjs` parses the block above and fails when the two lists
 drift, so keep that block as rows and not as prose.
 
-Known coverage gaps in the rows above, tracked in [#268]: on the `crates.io`
-line only `0.6.1` is pinned in `pg-compat/Cargo.toml`, so `0.5.10` is declared
-here and opened by no gate, and nothing compares the crates.io rows against that
-manifest the way the npm rows are compared against `readers.mjs`. The `nuget`
-row has no gate at all — `E4A.PostGuard` is a producer-only SDK, so a reader
-gate would need a decrypt path it does not have.
+Known coverage gap in the rows above, tracked in [#268]: the `nuget` row has no
+gate. `E4A.PostGuard` is a producer-only SDK (seal via pg-ffi, no unseal path),
+so a reader gate needs a decrypt capability the SDK does not have. Decided:
+leave it declared-but-ungated here rather than build that capability into this
+gate; the .NET seal direction is instead covered by promoting
+[postguard-e2e#21]'s version sweep to CI with decrypt legs, which already owns
+driving published NuGet versions against a target server.
 
 ## Deprecation
 

--- a/pg-compat/Cargo.lock
+++ b/pg-compat/Cargo.lock
@@ -56,6 +56,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bincode-next"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,9 +928,31 @@ name = "pg-compat"
 version = "0.0.0"
 dependencies = [
  "futures",
- "pg-core",
+ "pg-core 0.5.10",
+ "pg-core 0.6.1",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "pg-core"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4d538eda0ae961d100ba8ddf549197eb401bac7d24c14a1ba7aa5aeadae30b"
+dependencies = [
+ "aead",
+ "aes-gcm",
+ "base64ct",
+ "bincode",
+ "futures",
+ "ibe",
+ "ibs",
+ "irma",
+ "rand",
+ "serde",
+ "serde_json",
+ "subtle",
+ "tiny-keccak",
 ]
 
 [[package]]

--- a/pg-compat/Cargo.toml
+++ b/pg-compat/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 # that must keep reading what HEAD seals. Adding a version is this line plus one
 # `reader!` invocation in src/lib.rs.
 pg-core-0-6-1 = { package = "pg-core", version = "=0.6.1", features = ["stream"] }
+pg-core-0-5-10 = { package = "pg-core", version = "=0.5.10", features = ["stream"] }
 
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/pg-compat/README.md
+++ b/pg-compat/README.md
@@ -50,6 +50,11 @@ lines:
 Each version is a separate crate with separate types, which is why the check
 body is a macro instantiated per version rather than a generic function.
 
+`tests/support_window.rs` parses the `crates.io` row(s) out of
+`COMPATIBILITY.md`'s `Reader list` block and asserts they match `readers()`, so
+a version added to one and not the other goes red instead of drifting silently
+([#268]). Update the document's fenced block in the same change.
+
 ## Artifact layout
 
 The sealer writes a flat directory. Nothing in it is committed and nothing is
@@ -195,3 +200,4 @@ once per reader rather than once per case.
 [#252]: https://github.com/encryption4all/postguard/issues/252
 [#260]: https://github.com/encryption4all/postguard/issues/260
 [#261]: https://github.com/encryption4all/postguard/issues/261
+[#268]: https://github.com/encryption4all/postguard/issues/268

--- a/pg-compat/src/lib.rs
+++ b/pg-compat/src/lib.rs
@@ -22,6 +22,8 @@ use std::process::{Command, ExitStatus, Output};
 
 use serde::Deserialize;
 
+pub mod support_window;
+
 /// Manifest schema this reader understands. A newer set is an error, not a
 /// skip: silently reading nothing is the one failure mode a gate must not
 /// have.
@@ -371,14 +373,22 @@ macro_rules! reader {
 }
 
 reader!(v0_6_1, pg_core_0_6_1, "0.6.1");
+reader!(v0_5_10, pg_core_0_5_10, "0.5.10");
 
 /// Every published reader in the support window.
 pub fn readers() -> Vec<Reader> {
-    vec![Reader {
-        version: v0_6_1::VERSION,
-        wire_version: v0_6_1::WIRE_VERSION,
-        verify_case: v0_6_1::verify_case,
-    }]
+    vec![
+        Reader {
+            version: v0_6_1::VERSION,
+            wire_version: v0_6_1::WIRE_VERSION,
+            verify_case: v0_6_1::verify_case,
+        },
+        Reader {
+            version: v0_5_10::VERSION,
+            wire_version: v0_5_10::WIRE_VERSION,
+            verify_case: v0_5_10::verify_case,
+        },
+    ]
 }
 
 /// The reader for one published version, by the name it has on crates.io.

--- a/pg-compat/src/support_window.rs
+++ b/pg-compat/src/support_window.rs
@@ -1,0 +1,142 @@
+//! The support window as `COMPATIBILITY.md` declares it.
+//!
+//! `pg-compat/Cargo.toml`'s renamed dependencies (and the `readers()` they
+//! back) are this crate's copy of the crates.io half of that list, and a copy
+//! is only worth having if something compares it to the original. The
+//! `Reader list` section of `COMPATIBILITY.md` is a fenced block of
+//! `<registry> <package> <versions...>` rows for that reason, so the drift
+//! that matters — the window growing in the normative document while the
+//! gate keeps testing the versions it always tested — is a red run rather
+//! than an unnoticed one. Mirrors `pg-compat-js/src/support-window.mjs`,
+//! which does the same for the npm rows.
+//!
+//! Reformatting the block into prose or a table breaks the test in
+//! `tests/support_window.rs` on purpose: the check is what makes the
+//! sentence in the document true.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// The document the reader list is declared in.
+pub fn compatibility_doc() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../COMPATIBILITY.md")
+}
+
+/// First line of the block, and what marks it as the one to parse.
+const HEADER: &str = "# <registry> <package> <versions...>";
+
+/// The crates.io `pg-core` versions `COMPATIBILITY.md` declares as readers.
+pub fn declared_crates_io_readers(path: &Path) -> Vec<String> {
+    let text = fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    parse_crates_io_readers(&text, &path.display().to_string())
+}
+
+/// @param text the document
+/// @param what what to name when there is nothing to parse
+/// @returns one entry per version on a `crates.io` row
+pub fn parse_crates_io_readers(text: &str, what: &str) -> Vec<String> {
+    let rows = reader_list_block(text).unwrap_or_else(|| {
+        panic!(
+            "{what} has no reader-list block: expected a fenced block whose first line is \
+             \"{HEADER}\""
+        )
+    });
+
+    let mut versions = Vec::new();
+    for row in rows {
+        let trimmed = row.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        let mut fields = trimmed.split_whitespace();
+        let registry = fields.next().unwrap_or_default();
+        let package = fields.next().unwrap_or_default();
+        let row_versions: Vec<&str> = fields.collect();
+
+        if registry != "crates.io" {
+            continue;
+        }
+        if row_versions.is_empty() {
+            panic!("{what}: the crates.io row for {package} lists no version");
+        }
+        assert_eq!(
+            package, "pg-core",
+            "{what}: unexpected crates.io package {package}, pg-compat only reads pg-core",
+        );
+        versions.extend(row_versions.into_iter().map(str::to_string));
+    }
+
+    // An empty list would compare equal to nothing and make the drift check
+    // vacuous, which is the failure this module exists to catch.
+    assert!(
+        !versions.is_empty(),
+        "{what}: the reader-list block holds no crates.io row",
+    );
+
+    versions
+}
+
+/// The rows of the fenced block whose first line is [`HEADER`], or `None`
+/// when the document has no such block.
+fn reader_list_block(text: &str) -> Option<Vec<&str>> {
+    let mut inside_fence = false;
+    let mut rows: Option<Vec<&str>> = None;
+
+    for line in text.lines() {
+        if line.trim_start().starts_with("```") {
+            if rows.is_some() {
+                return rows;
+            }
+            inside_fence = !inside_fence;
+            continue;
+        }
+
+        if let Some(r) = rows.as_mut() {
+            r.push(line);
+        } else if inside_fence && line.trim() == HEADER {
+            rows = Some(Vec::new());
+        }
+    }
+
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_document_with_no_fenced_block_is_an_error() {
+        let result = std::panic::catch_unwind(|| parse_crates_io_readers("prose, no block", "doc"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[should_panic(expected = "holds no crates.io row")]
+    fn a_block_with_only_npm_rows_is_an_error() {
+        parse_crates_io_readers(
+            "```\n# <registry> <package> <versions...>\nnpm @e4a/pg-js 2.3.3\n```\n",
+            "doc",
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "lists no version")]
+    fn a_crates_io_row_with_no_version_is_an_error() {
+        parse_crates_io_readers(
+            "```\n# <registry> <package> <versions...>\ncrates.io pg-core\n```\n",
+            "doc",
+        );
+    }
+
+    #[test]
+    fn a_well_formed_block_yields_every_declared_version() {
+        let versions = parse_crates_io_readers(
+            "```\n# <registry> <package> <versions...>\ncrates.io pg-core 0.6.1 0.5.10\nnpm \
+             @e4a/pg-js 2.3.3\n```\n",
+            "doc",
+        );
+        assert_eq!(versions, vec!["0.6.1", "0.5.10"]);
+    }
+}

--- a/pg-compat/tests/support_window.rs
+++ b/pg-compat/tests/support_window.rs
@@ -1,0 +1,26 @@
+//! The crates.io half of #268: nothing compared the `Reader list` block in
+//! `COMPATIBILITY.md` against what `pg-compat` actually pins, so a row could
+//! drift from the manifest with nothing noticing — the same silent-green
+//! class the wire-compat gate exists to close. This is the crates.io mirror
+//! of `pg-compat-js/test/manifest.test.mjs`'s npm check.
+
+use pg_compat::readers;
+use pg_compat::support_window::{compatibility_doc, declared_crates_io_readers};
+
+#[test]
+fn the_support_window_is_the_crates_io_reader_list_in_compatibility_md() {
+    let mut declared = declared_crates_io_readers(&compatibility_doc());
+    declared.sort();
+
+    let mut pinned: Vec<String> = readers()
+        .into_iter()
+        .map(|r| r.version.to_string())
+        .collect();
+    pinned.sort();
+
+    assert_eq!(
+        declared, pinned,
+        "COMPATIBILITY.md's crates.io reader list and pg-compat's readers() have drifted; the \
+         document decides",
+    );
+}


### PR DESCRIPTION
## Summary

- Pin `pg-core` 0.5.10 as a second reader in `pg-compat` — it opens the HEAD-sealed sample set cleanly, so the row `COMPATIBILITY.md` already declared was previously opened by no gate.
- Add `pg-compat/tests/support_window.rs`, the crates.io mirror of `pg-compat-js/test/manifest.test.mjs`: it parses the `crates.io` rows out of `COMPATIBILITY.md`'s `Reader list` block and fails when they drift from `pg-compat`'s `readers()`.
- Record the nuget-row decision in `COMPATIBILITY.md`: leave `E4A.PostGuard` declared-but-ungated here (it's producer-only, no decrypt path), and cover the .NET seal direction instead by promoting postguard-e2e#21's version sweep — already tracked there, not duplicated in this repo.

Closes #268