### PR TITLE
feat(cryptify): persist upload-session state to SQLite (write-through)

### DIFF
--- a/cryptify/CLAUDE.md
+++ b/cryptify/CLAUDE.md
@@ -78,25 +78,58 @@ Release-plz automation.
   file to extract attributes; `sender` (`pbdf.sidn-pbdf.email.email`) becomes
   known.
 - **Purge timer:** `state.expirations` (a `BTreeMap` populated in `Store::create`
-  at `src/store.rs:292` with `Instant::now() + self.shared.idle_ttl`) is what
+  at `src/store.rs:591` with `Instant::now() + self.shared.idle_ttl`) is what
   `purge_task` walks. `idle_ttl` defaults to `DEFAULT_UPLOAD_SESSION_IDLE_TIMEOUT_SECS`
   (`60 * 60`, 1 hour); this is a resettable idle timeout, not a hard deadline from
-  creation. `Store::touch` (`src/store.rs:318`) removes the old `expirations` key and
+  creation. `Store::touch` (`src/store.rs:609`) removes the old `expirations` key and
   re-inserts `Instant::now() + idle_ttl` on each chunk PUT and status check, so the
   hour counts from the last activity (see the `touch_extends_eviction_deadline` test
-  at `src/store.rs:545`). `FileState.expires` (current_time + 14d) is NOT what drives
+  at `src/store.rs:879`). `FileState.expires` (current_time + 14d) is NOT what drives
   eviction; it's a different field, never read by the purge loop. When tracing
   eviction, follow `state.expirations`.
 - Purge does not delete the on-disk file. Rejecting at finalize must manually
   `tokio::fs::remove_file` and `store.remove(uuid)`.
-- In-memory only, no persistence. Process restart wipes all upload sessions and
-  orphans on-disk files in `data_dir/` (tracked as cryptify#116).
-- Per-sender usage tracking is a `HashMap` in `StoreState.usage`, optionally backed
-  by SQLite when config `usage_db = "<path>"` is set: `UsageDb` (rusqlite,
-  `bundled`) is the source of truth, the map is a cache loaded on startup and
-  written through on each `record_upload` (which also prunes rows outside the 14d
-  rolling window). `usage_db` unset means in-memory only (old behaviour). A
-  configured-but-unopenable DB panics at startup.
+- The in-memory `HashMap` is still what every request reads. Session state is now
+  *written through* to SQLite (postguard#302) but nothing loads it back, so a
+  process restart still wipes all upload sessions and still orphans on-disk files
+  in `data_dir/`. Restore-on-boot is postguard#303; until it lands the rows are
+  write-only and the user-visible bug (chunk PUT 404 after a deploy) is unchanged.
+- **`usage_db` is not just usage any more: it names cryptify's whole SQLite state
+  database.** One file, one `rusqlite::Connection` behind one `Mutex` (`StateDb`
+  in `src/store.rs`), two tables — `usage` and `upload_sessions`. Both schemas are
+  created with `CREATE TABLE IF NOT EXISTS` at startup, so an existing
+  usage-only database gains the new table in place. `usage_db` unset means both
+  stay in memory only (the old behaviour, and what every unit test uses); a
+  configured-but-unopenable DB panics at startup. The key name was left alone on
+  purpose: renaming it would be an ops-visible change for zero behavioural gain,
+  and prod's `conf/config.toml` does not set it at all (only `config.dev.toml`
+  does), so **session persistence is off in any deployment that never set
+  `usage_db`** — check that before assuming #303 will do anything there.
+- Per-sender usage: the map in `StoreState.usage` is a cache, the table is the
+  source of truth, loaded on startup (`load_all_usage`) and written through on each
+  `record_upload` (`record_usage`, which also prunes rows outside the 14d rolling
+  window).
+- Upload sessions: `Store::persist_session(id, &FileState)` writes one upsert, and
+  it is called at each of the three transitions **before the handler responds** —
+  `Store::create` (init), `upload_chunk` after the rolling token advances, and
+  `upload_finalize` right after `sender` is set and before the email goes out. The
+  reverse edges matter as much: `Store::remove` and the purge task both delete the
+  row, so an unresumable session never leaves one behind (without that the table
+  would grow without bound and a future restore would resurrect sessions the purge
+  already killed). DB errors are logged, never propagated — persistence must not
+  add a way for a healthy upload to fail.
+- Three things about the `upload_sessions` schema that are not guessable:
+  `recovery_token_hash` stores `sha256(recovery_token)` hex, never the plaintext
+  bearer credential, so a restore path must compare hashes rather than tokens;
+  `created_at` is deliberately absent from the upsert's `DO UPDATE SET` list, which
+  is what keeps it recording when the session began; and there is **no
+  expected-size column**, because clients send `Content-Range: bytes <s>-<e>/*` on
+  chunk PUTs and the total is genuinely unknown to the server until finalize
+  declares it (finalize then rejects a declaration that disagrees with `uploaded`).
+- `email::Language::code()` (`"EN"`/`"NL"`) is what the `mail_lang` column stores,
+  and `language_code_matches_serde_representation` in `email.rs` pins it to the
+  serde/wire form so a restored session can't come back with a `mailLang` no client
+  would send.
 
 ## api-description.yaml is tied to the mounted routes by a test
 `api_routes()` in `src/main.rs` is the single mount list; `build_rocket` mounts it

--- a/cryptify/src/email.rs
+++ b/cryptify/src/email.rs
@@ -125,6 +125,20 @@ pub enum Language {
     Nl,
 }
 
+impl Language {
+    /// Stable two-letter code, deliberately identical to the serde
+    /// representation the `mailLang` field uses on the wire. Persisting the
+    /// same token means a restored session and a fresh one carry the same
+    /// value, and `language_code_matches_serde_representation` keeps the two
+    /// from drifting apart.
+    pub fn code(&self) -> &'static str {
+        match self {
+            Language::En => "EN",
+            Language::Nl => "NL",
+        }
+    }
+}
+
 struct MailStrings<'a> {
     subject_str: &'a str,
     sender_str: &'a str,
@@ -977,6 +991,19 @@ mod tests {
         state.sender = None;
         let rendered = render_confirmation_email(&state, &config, "uuid-xyz").expect("render");
         assert!(rendered.is_none());
+    }
+
+    /// `Language::code` is what `store.rs` persists in the `mail_lang`
+    /// column, and the wire uses the serde representation. They have to be
+    /// the same token, or a restored session would come back with a
+    /// `mailLang` no client sent — so pin them to each other rather than to
+    /// two hand-written literals.
+    #[test]
+    fn language_code_matches_serde_representation() {
+        for lang in [Language::En, Language::Nl] {
+            let serialized = serde_json::to_string(&lang).expect("serialize language");
+            assert_eq!(serialized, format!("\"{}\"", lang.code()));
+        }
     }
 
     #[test]

--- a/cryptify/src/main.rs
+++ b/cryptify/src/main.rs
@@ -788,6 +788,12 @@ async fn upload_chunk(
         response_token: shasum.clone(),
     });
 
+    // Write the advanced chain through to SQLite before the response leaves:
+    // the client treats the token it gets back as committed, so the durable
+    // row must not lag behind it. A database failure is logged, not
+    // propagated — the chunk is already on disk and in memory.
+    store.persist_session(uuid, &state);
+
     drop(state);
     store.touch(uuid);
 
@@ -1006,6 +1012,11 @@ async fn upload_finalize(
 
     state.sender = sender.clone();
     state.sender_attributes = sender_attributes;
+
+    // Persist the finalize transition (the sender is only known now) before
+    // the notification email goes out, so the durable row is never behind the
+    // side effects the client's request produced.
+    store.persist_session(uuid, &state);
 
     send_email(config, &state, uuid).await.map_err(|e| {
         log::error!("could not send notification email: {}", e);
@@ -3107,6 +3118,175 @@ mod integration {
             .dispatch()
             .await
             .status()
+    }
+
+    /// Boot Rocket through the same [`build_rocket`] seam as [`test_client`],
+    /// but with `usage_db` pointed at a SQLite file inside the per-test
+    /// `data_dir` — that key names cryptify's whole state database, so setting
+    /// it is what turns upload-session persistence on. Returns the database
+    /// path so a test can read the rows back with plain SQL, independent of
+    /// the code that wrote them.
+    async fn test_client_with_state_db(
+        setup: &TestSetup,
+    ) -> (Client, std::path::PathBuf, std::path::PathBuf) {
+        let (figment, dir) = test_figment();
+        let db_path = dir.join("state.db");
+        let figment = figment.merge(("usage_db", db_path.to_string_lossy().to_string()));
+        let vk = Parameters {
+            format_version: 0,
+            public_key: VerifyingKey(setup.ibs_pk.0.clone()),
+        };
+        let client = Client::tracked(build_rocket(figment, vk))
+            .await
+            .expect("valid rocket");
+        (client, dir, db_path)
+    }
+
+    /// The columns an upload session's durable row must show after a
+    /// transition, read straight out of SQLite.
+    struct SessionRow {
+        uploaded: i64,
+        cryptify_token: String,
+        prev_token: Option<String>,
+        prev_uploaded: Option<i64>,
+        recovery_token_hash: String,
+        api_key_tenant: Option<String>,
+        sender: Option<String>,
+        created_at: i64,
+        last_active_at: i64,
+    }
+
+    fn read_session_row(db_path: &std::path::Path, uuid: &str) -> Option<SessionRow> {
+        let conn = rusqlite::Connection::open(db_path).expect("open state database");
+        conn.query_row(
+            "SELECT uploaded, cryptify_token, prev_token, prev_uploaded,
+                    recovery_token_hash, api_key_tenant, sender, created_at, last_active_at
+             FROM upload_sessions WHERE uuid = ?1",
+            rusqlite::params![uuid],
+            |row| {
+                Ok(SessionRow {
+                    uploaded: row.get(0)?,
+                    cryptify_token: row.get(1)?,
+                    prev_token: row.get(2)?,
+                    prev_uploaded: row.get(3)?,
+                    recovery_token_hash: row.get(4)?,
+                    api_key_tenant: row.get(5)?,
+                    sender: row.get(6)?,
+                    created_at: row.get(7)?,
+                    last_active_at: row.get(8)?,
+                })
+            },
+        )
+        .ok()
+    }
+
+    /// The done bar for postguard#302: after real HTTP init and chunk
+    /// requests, the session is on disk in SQLite with the token the client
+    /// was handed. Driven through the router, so it also proves the
+    /// write-through actually runs inside the handlers — not just that
+    /// `Store` can write a row when called directly.
+    #[rocket::async_test]
+    async fn session_rows_are_visible_in_sqlite_after_init_and_chunk() {
+        let mut rng = rand08::thread_rng();
+        let setup = TestSetup::new(&mut rng);
+        let (client, dir, db_path) = test_client_with_state_db(&setup).await;
+
+        let (uuid, init_token, status) = do_init(&client, SENDER_EMAIL).await;
+        assert_eq!(status, Status::Ok);
+
+        let row = read_session_row(&db_path, &uuid).expect("init must persist a session row");
+        assert_eq!(row.uploaded, 0);
+        assert_eq!(
+            row.cryptify_token, init_token,
+            "the persisted token must be the one the client was told to use next"
+        );
+        assert_eq!(row.prev_token, None, "no chunk committed yet");
+        assert_eq!(row.prev_uploaded, None);
+        assert_eq!(row.sender, None, "sender is only known at finalize");
+        assert_eq!(
+            row.api_key_tenant, None,
+            "this request presented no API key"
+        );
+        assert_eq!(
+            row.recovery_token_hash.len(),
+            64,
+            "recovery token is stored as a hex SHA-256, never in the clear"
+        );
+        assert_eq!(row.created_at, row.last_active_at);
+
+        let chunk = b"a chunk of sealed-looking bytes";
+        let (chunk_status, next_token) = do_chunk(&client, &uuid, &init_token, chunk, 0).await;
+        assert_eq!(chunk_status, Status::Ok);
+
+        let row = read_session_row(&db_path, &uuid).expect("chunk must persist the session row");
+        assert_eq!(row.uploaded, chunk.len() as i64);
+        assert_eq!(
+            row.cryptify_token, next_token,
+            "the row must carry the advanced token the response returned"
+        );
+        assert_eq!(
+            row.prev_token.as_deref(),
+            Some(init_token.as_str()),
+            "the replay record must persist so a restart can still accept a retry"
+        );
+        assert_eq!(row.prev_uploaded, Some(0));
+        assert!(row.last_active_at >= row.created_at);
+
+        // The client-visible surface is unchanged: nothing about persistence
+        // is exposed on the responses, and the flow still completes.
+        assert!(!next_token.is_empty());
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// Finalize is the third transition, and the only one that learns the
+    /// sender. Runs the whole flow against a real sealed payload.
+    #[rocket::async_test]
+    async fn finalize_persists_the_sender_to_sqlite() {
+        let mut rng = rand08::thread_rng();
+        let setup = TestSetup::new(&mut rng);
+        let sealed = seal_payload(&setup, b"hello persistence").await;
+        let (client, dir, db_path) = test_client_with_state_db(&setup).await;
+
+        let (uuid, token, status) = do_init(&client, SENDER_EMAIL).await;
+        assert_eq!(status, Status::Ok);
+        let (chunk_status, token) = do_chunk(&client, &uuid, &token, &sealed, 0).await;
+        assert_eq!(chunk_status, Status::Ok);
+        assert_eq!(
+            do_finalize(&client, &uuid, &token, sealed.len() as u64).await,
+            Status::Ok
+        );
+
+        let row = read_session_row(&db_path, &uuid).expect("row after finalize");
+        assert_eq!(
+            row.sender.as_deref(),
+            Some(SENDER_EMAIL),
+            "finalize must persist the sender it unsealed"
+        );
+        assert_eq!(row.uploaded, sealed.len() as i64);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// Persistence must not change any client-visible behaviour, so the same
+    /// happy path has to pass with the state database switched on.
+    #[rocket::async_test]
+    async fn upload_happy_path_is_unchanged_with_persistence_enabled() {
+        let mut rng = rand08::thread_rng();
+        let setup = TestSetup::new(&mut rng);
+        let sealed = seal_payload(&setup, b"hello persistent integration test").await;
+        let (client, dir, _db_path) = test_client_with_state_db(&setup).await;
+
+        let (uuid, token, status) = do_init(&client, SENDER_EMAIL).await;
+        assert_eq!(status, Status::Ok);
+        let (chunk_status, token) = do_chunk(&client, &uuid, &token, &sealed, 0).await;
+        assert_eq!(chunk_status, Status::Ok);
+        assert_eq!(
+            do_finalize(&client, &uuid, &token, sealed.len() as u64).await,
+            Status::Ok
+        );
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[rocket::async_test]

--- a/cryptify/src/store.rs
+++ b/cryptify/src/store.rs
@@ -108,24 +108,148 @@ struct UploadRecord {
     bytes: u64,
 }
 
-/// SQLite-backed persistence for the rolling-quota usage state.
+/// One row of the `upload_sessions` table: the durable projection of a
+/// [`FileState`], carrying everything needed to rebuild an in-flight upload
+/// after a restart.
 ///
-/// The in-memory `StoreState.usage` map is only a cache: this database is
-/// the source of truth, so per-sender quota survives pod restarts and
-/// redeploys. On startup the full table is loaded back into the cache
-/// ([`UsageDb::load_all`]); every accounted upload is written through here
-/// ([`UsageDb::record`]) before the cache is updated.
+/// Two fields are deliberately *not* verbatim copies of `FileState`:
+///
+/// - `recovery_token_hash` is `sha256(recovery_token)`, hex-encoded. The
+///   plaintext is a bearer credential for `GET /fileupload/{uuid}/status`,
+///   so it is stored the way a password would be — a restore path compares
+///   `sha256(presented)` against this column rather than the token itself.
+/// - `sender_attributes` is the JSON encoding of `FileState`'s
+///   `Vec<(String, String)>`, so a variable-length list fits one column.
+///
+/// Nothing reads these rows back yet: restore-on-boot is postguard#303.
+/// This step only makes the state durable, with no client-visible change.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PersistedSession {
+    uuid: String,
+    /// Current head of the rolling-token chain (`FileState::cryptify_token`).
+    cryptify_token: String,
+    /// The three [`LastChunkRecord`] fields, all `None` until the first chunk
+    /// is committed. `prev_token` is the previous `cryptifytoken` — the value
+    /// the client sent on the last accepted chunk, which the idempotent-replay
+    /// path matches against.
+    prev_token: Option<String>,
+    prev_uploaded: Option<u64>,
+    response_token: Option<String>,
+    recovery_token_hash: String,
+    /// Bytes received so far. There is no "expected size" counterpart:
+    /// clients send `Content-Range: bytes <start>-<end>/*` on chunk PUTs, so
+    /// the total is unknown to the server until finalize declares it (and
+    /// finalize rejects a declaration that disagrees with `uploaded`).
+    uploaded: u64,
+    /// Absolute unix timestamp of the 14-day on-disk expiry
+    /// (`FileState::expires`), not the idle-eviction deadline.
+    expires: i64,
+    /// Recipient list rendered by `Mailboxes`' `Display`, which its `FromStr`
+    /// parses back.
+    recipients: String,
+    mail_content: String,
+    /// `"EN"` / `"NL"` — [`email::Language::code`], pinned to the serde
+    /// representation by a test in `email.rs`.
+    mail_lang: String,
+    confirm: bool,
+    notify_recipients: bool,
+    source_channel: String,
+    client_version: Option<String>,
+    client_app: Option<String>,
+    api_key_tenant: Option<String>,
+    api_key_validation_failed: bool,
+    /// Populated at finalize, once the sealed file has been unsealed.
+    sender: Option<String>,
+    sender_attributes: String,
+    /// Set when the row is first inserted and never overwritten afterwards
+    /// (the upsert's `DO UPDATE` list omits it on purpose).
+    created_at: i64,
+    /// Refreshed on every persisted transition.
+    last_active_at: i64,
+}
+
+impl PersistedSession {
+    /// Project a live [`FileState`] onto its durable row. `now` is used for
+    /// `last_active_at`, and for `created_at` on the initial insert only —
+    /// on an update the upsert keeps the stored value.
+    fn from_state(uuid: &str, state: &FileState, now: i64) -> Self {
+        let (prev_token, prev_uploaded, response_token) = match state.last_chunk.as_ref() {
+            Some(last) => (
+                Some(last.prev_token.clone()),
+                Some(last.prev_uploaded),
+                Some(last.response_token.clone()),
+            ),
+            None => (None, None, None),
+        };
+
+        PersistedSession {
+            uuid: uuid.to_owned(),
+            cryptify_token: state.cryptify_token.clone(),
+            prev_token,
+            prev_uploaded,
+            response_token,
+            recovery_token_hash: hash_recovery_token(&state.recovery_token),
+            uploaded: state.uploaded,
+            expires: state.expires,
+            recipients: state.recipients.to_string(),
+            mail_content: state.mail_content.clone(),
+            mail_lang: state.mail_lang.code().to_owned(),
+            confirm: state.confirm,
+            notify_recipients: state.notify_recipients,
+            source_channel: state.source_channel.clone(),
+            client_version: state.client_version.clone(),
+            client_app: state.client_app.clone(),
+            api_key_tenant: state.api_key_tenant.clone(),
+            api_key_validation_failed: state.api_key_validation_failed,
+            sender: state.sender.clone(),
+            // Infallible in practice (a Vec of string pairs); fall back to an
+            // empty list rather than failing the upload over metadata.
+            sender_attributes: serde_json::to_string(&state.sender_attributes)
+                .unwrap_or_else(|_| "[]".to_owned()),
+            created_at: now,
+            last_active_at: now,
+        }
+    }
+}
+
+/// Hex-encoded SHA-256 of an upload session's recovery token. See
+/// [`PersistedSession::recovery_token_hash`].
+fn hash_recovery_token(token: &str) -> String {
+    use sha2::Digest;
+    let mut hash = sha2::Sha256::new();
+    hash.update(token.as_bytes());
+    crate::bytes_to_hex(&hash.finalize())
+}
+
+/// SQLite-backed persistence for cryptify's durable state: the rolling-quota
+/// `usage` table and the `upload_sessions` table.
+///
+/// Both live in the single database file named by the `usage_db` config key
+/// (one file to mount and back up), on one connection, so a session write and
+/// a usage write can never disagree about which file they landed in.
+///
+/// For usage, the in-memory `StoreState.usage` map is only a cache: this
+/// database is the source of truth, so per-sender quota survives pod restarts
+/// and redeploys. On startup the full table is loaded back into the cache
+/// ([`StateDb::load_all_usage`]); every accounted upload is written through
+/// here ([`StateDb::record_usage`]) before the cache is updated.
+///
+/// For sessions the direction is currently one-way: every state transition is
+/// written through ([`StateDb::upsert_session`]) and eviction deletes the row
+/// ([`StateDb::delete_session`]), but nothing loads rows back yet — that is
+/// postguard#303.
 ///
 /// The connection is wrapped in a `Mutex` because `rusqlite::Connection`
 /// is `Send` but not `Sync`, and `SharedState` is shared across the purge
 /// task via an `Arc`.
-struct UsageDb {
+struct StateDb {
     conn: std::sync::Mutex<rusqlite::Connection>,
 }
 
-impl UsageDb {
+impl StateDb {
     /// Open (creating if necessary) the SQLite database at `path` and ensure
-    /// the schema exists.
+    /// the schema exists. Called once at startup, so an existing database
+    /// from before upload-session persistence simply gains the new table.
     fn open(path: &str) -> rusqlite::Result<Self> {
         let conn = rusqlite::Connection::open(path)?;
         // WAL keeps writes from blocking the (rare) concurrent reads and
@@ -144,9 +268,171 @@ impl UsageDb {
             "CREATE INDEX IF NOT EXISTS idx_usage_email_ts ON usage (email, timestamp)",
             [],
         )?;
-        Ok(UsageDb {
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS upload_sessions (
+                 uuid                      TEXT    PRIMARY KEY,
+                 cryptify_token            TEXT    NOT NULL,
+                 prev_token                TEXT,
+                 prev_uploaded             INTEGER,
+                 response_token            TEXT,
+                 recovery_token_hash       TEXT    NOT NULL,
+                 uploaded                  INTEGER NOT NULL,
+                 expires                   INTEGER NOT NULL,
+                 recipients                TEXT    NOT NULL,
+                 mail_content              TEXT    NOT NULL,
+                 mail_lang                 TEXT    NOT NULL,
+                 confirm                   INTEGER NOT NULL,
+                 notify_recipients         INTEGER NOT NULL,
+                 source_channel            TEXT    NOT NULL,
+                 client_version            TEXT,
+                 client_app                TEXT,
+                 api_key_tenant            TEXT,
+                 api_key_validation_failed INTEGER NOT NULL,
+                 sender                    TEXT,
+                 sender_attributes         TEXT    NOT NULL,
+                 created_at                INTEGER NOT NULL,
+                 last_active_at            INTEGER NOT NULL
+             )",
+            [],
+        )?;
+        Ok(StateDb {
             conn: std::sync::Mutex::new(conn),
         })
+    }
+
+    /// Write a session's current state, inserting on the first transition and
+    /// updating on every later one. `created_at` is omitted from the update
+    /// list so it keeps recording when the session began.
+    ///
+    /// Errors are logged rather than propagated, for the same reason
+    /// [`StateDb::record_usage`] swallows them: this step must not add a way
+    /// for an otherwise-successful upload to fail. The in-memory state stays
+    /// authoritative for the lifetime of the process either way.
+    fn upsert_session(&self, session: &PersistedSession) {
+        let conn = self.conn.lock().unwrap();
+        if let Err(e) = conn.execute(
+            "INSERT INTO upload_sessions (
+                 uuid, cryptify_token, prev_token, prev_uploaded, response_token,
+                 recovery_token_hash, uploaded, expires, recipients, mail_content,
+                 mail_lang, confirm, notify_recipients, source_channel, client_version,
+                 client_app, api_key_tenant, api_key_validation_failed, sender,
+                 sender_attributes, created_at, last_active_at
+             ) VALUES (
+                 ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11,
+                 ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22
+             )
+             ON CONFLICT(uuid) DO UPDATE SET
+                 cryptify_token            = excluded.cryptify_token,
+                 prev_token                = excluded.prev_token,
+                 prev_uploaded             = excluded.prev_uploaded,
+                 response_token            = excluded.response_token,
+                 recovery_token_hash       = excluded.recovery_token_hash,
+                 uploaded                  = excluded.uploaded,
+                 expires                   = excluded.expires,
+                 recipients                = excluded.recipients,
+                 mail_content              = excluded.mail_content,
+                 mail_lang                 = excluded.mail_lang,
+                 confirm                   = excluded.confirm,
+                 notify_recipients         = excluded.notify_recipients,
+                 source_channel            = excluded.source_channel,
+                 client_version            = excluded.client_version,
+                 client_app                = excluded.client_app,
+                 api_key_tenant            = excluded.api_key_tenant,
+                 api_key_validation_failed = excluded.api_key_validation_failed,
+                 sender                    = excluded.sender,
+                 sender_attributes         = excluded.sender_attributes,
+                 last_active_at            = excluded.last_active_at",
+            rusqlite::params![
+                session.uuid,
+                session.cryptify_token,
+                session.prev_token,
+                session.prev_uploaded.map(|v| v as i64),
+                session.response_token,
+                session.recovery_token_hash,
+                session.uploaded as i64,
+                session.expires,
+                session.recipients,
+                session.mail_content,
+                session.mail_lang,
+                session.confirm,
+                session.notify_recipients,
+                session.source_channel,
+                session.client_version,
+                session.client_app,
+                session.api_key_tenant,
+                session.api_key_validation_failed,
+                session.sender,
+                session.sender_attributes,
+                session.created_at,
+                session.last_active_at,
+            ],
+        ) {
+            log::error!("Failed to persist upload session {}: {}", session.uuid, e);
+        }
+    }
+
+    /// Drop a session's row once it can never be resumed — evicted by the
+    /// purge task, or explicitly removed (e.g. a finalize rejected for quota,
+    /// which also deletes the on-disk file).
+    fn delete_session(&self, uuid: &str) {
+        let conn = self.conn.lock().unwrap();
+        if let Err(e) = conn.execute(
+            "DELETE FROM upload_sessions WHERE uuid = ?1",
+            rusqlite::params![uuid],
+        ) {
+            log::error!("Failed to delete persisted upload session {}: {}", uuid, e);
+        }
+    }
+
+    /// Read one persisted session back. Only tests need this today; the
+    /// production reader arrives with restore-on-boot (postguard#303).
+    #[cfg(test)]
+    fn load_session(&self, uuid: &str) -> Option<PersistedSession> {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row(
+            "SELECT uuid, cryptify_token, prev_token, prev_uploaded, response_token,
+                    recovery_token_hash, uploaded, expires, recipients, mail_content,
+                    mail_lang, confirm, notify_recipients, source_channel, client_version,
+                    client_app, api_key_tenant, api_key_validation_failed, sender,
+                    sender_attributes, created_at, last_active_at
+             FROM upload_sessions WHERE uuid = ?1",
+            rusqlite::params![uuid],
+            |row| {
+                Ok(PersistedSession {
+                    uuid: row.get(0)?,
+                    cryptify_token: row.get(1)?,
+                    prev_token: row.get(2)?,
+                    prev_uploaded: row.get::<_, Option<i64>>(3)?.map(|v| v as u64),
+                    response_token: row.get(4)?,
+                    recovery_token_hash: row.get(5)?,
+                    uploaded: row.get::<_, i64>(6)? as u64,
+                    expires: row.get(7)?,
+                    recipients: row.get(8)?,
+                    mail_content: row.get(9)?,
+                    mail_lang: row.get(10)?,
+                    confirm: row.get(11)?,
+                    notify_recipients: row.get(12)?,
+                    source_channel: row.get(13)?,
+                    client_version: row.get(14)?,
+                    client_app: row.get(15)?,
+                    api_key_tenant: row.get(16)?,
+                    api_key_validation_failed: row.get(17)?,
+                    sender: row.get(18)?,
+                    sender_attributes: row.get(19)?,
+                    created_at: row.get(20)?,
+                    last_active_at: row.get(21)?,
+                })
+            },
+        )
+        .ok()
+    }
+
+    /// Number of persisted sessions, for tests asserting eviction.
+    #[cfg(test)]
+    fn session_count(&self) -> i64 {
+        let conn = self.conn.lock().unwrap();
+        conn.query_row("SELECT COUNT(*) FROM upload_sessions", [], |row| row.get(0))
+            .unwrap_or(-1)
     }
 
     /// Load every persisted record into an in-memory map, grouped by email
@@ -154,7 +440,7 @@ impl UsageDb {
     /// in-memory path would have built. Stale records are intentionally not
     /// pruned here: pruning is relative to the caller-supplied `now`, which
     /// only the request path knows.
-    fn load_all(&self) -> rusqlite::Result<HashMap<String, VecDeque<UploadRecord>>> {
+    fn load_all_usage(&self) -> rusqlite::Result<HashMap<String, VecDeque<UploadRecord>>> {
         let conn = self.conn.lock().unwrap();
         let mut stmt =
             conn.prepare("SELECT email, timestamp, bytes FROM usage ORDER BY timestamp ASC")?;
@@ -181,7 +467,7 @@ impl UsageDb {
     /// active senders. Errors are logged rather than propagated: a database
     /// hiccup must not fail an otherwise-successful upload, and the in-memory
     /// cache still reflects the record for the lifetime of the process.
-    fn record(&self, email: &str, bytes: u64, now: i64) {
+    fn record_usage(&self, email: &str, bytes: u64, now: i64) {
         let conn = self.conn.lock().unwrap();
         if let Err(e) = conn.execute(
             "INSERT INTO usage (email, timestamp, bytes) VALUES (?1, ?2, ?3)",
@@ -216,10 +502,10 @@ struct SharedState {
     notify: Notify,
     idle_ttl: Duration,
     metrics: Arc<Metrics>,
-    /// SQLite source of truth for rolling-quota usage. `None` keeps usage in
-    /// memory only (the pre-persistence behaviour, used by unit tests and
-    /// when `usage_db` is unset in config).
-    usage_db: Option<UsageDb>,
+    /// SQLite handle backing rolling-quota usage and upload-session state.
+    /// `None` keeps both in memory only (the pre-persistence behaviour, used
+    /// by unit tests and when `usage_db` is unset in config).
+    db: Option<StateDb>,
 }
 
 pub struct Store {
@@ -237,23 +523,22 @@ impl Store {
     }
 
     /// Construct a store with the given idle-eviction window. When
-    /// `usage_db` is `Some(path)` the rolling-quota state is backed by a
-    /// SQLite database at that path: existing usage is loaded from disk on
-    /// startup and every accounted upload is written through, so quota
-    /// survives process restarts. A configured-but-unopenable database is a
-    /// deployment error and panics here, the same way a malformed config
-    /// does — better a loud startup failure than silently losing quota
-    /// persistence.
-    pub fn with_idle_ttl(
-        idle_ttl: Duration,
-        metrics: Arc<Metrics>,
-        usage_db: Option<&str>,
-    ) -> Self {
-        let (usage_db, usage) = match usage_db {
+    /// `db_path` is `Some(path)` the durable state is backed by a SQLite
+    /// database at that path (the `usage_db` config key): existing usage is
+    /// loaded from disk on startup and every accounted upload is written
+    /// through, so quota survives process restarts, and every upload-session
+    /// transition is written through to the `upload_sessions` table. The
+    /// schema is created here if absent, so an existing database from before
+    /// session persistence just gains the new table. A
+    /// configured-but-unopenable database is a deployment error and panics
+    /// here, the same way a malformed config does — better a loud startup
+    /// failure than silently losing persistence.
+    pub fn with_idle_ttl(idle_ttl: Duration, metrics: Arc<Metrics>, db_path: Option<&str>) -> Self {
+        let (db, usage) = match db_path {
             Some(path) => {
-                let db = UsageDb::open(path)
-                    .unwrap_or_else(|e| panic!("Failed to open usage database at {}: {}", path, e));
-                let usage = db.load_all().unwrap_or_else(|e| {
+                let db = StateDb::open(path)
+                    .unwrap_or_else(|e| panic!("Failed to open state database at {}: {}", path, e));
+                let usage = db.load_all_usage().unwrap_or_else(|e| {
                     panic!("Failed to load usage records from {}: {}", path, e)
                 });
                 let records: usize = usage.values().map(VecDeque::len).sum();
@@ -281,7 +566,7 @@ impl Store {
                 notify: Notify::new(),
                 idle_ttl,
                 metrics,
-                usage_db,
+                db,
             }),
         };
 
@@ -290,6 +575,12 @@ impl Store {
     }
 
     pub fn create(&self, id: String, filestate: FileState) {
+        // Write-through before the entry becomes visible in memory (and so
+        // before the handler can answer the client), keeping the database at
+        // least as far ahead as the response the client acted on. Done
+        // outside the `state` mutex so a slow disk never blocks lookups.
+        self.persist_session(&id, &filestate);
+
         let mut state = self.shared.state.lock().unwrap(); // this will only panic if we already panicked elsewhere while holding the mutex, which is fine.
         state.files.insert(
             id.clone(),
@@ -331,7 +622,33 @@ impl Store {
         self.shared.notify.notify_one();
     }
 
+    /// Write the session's current state through to the `upload_sessions`
+    /// table. A no-op when no database is configured.
+    ///
+    /// Called at every transition — session creation, an accepted chunk, and
+    /// finalize — *before* the handler builds its response, so the durable
+    /// row never lags behind what the client was told. The write is a single
+    /// small upsert under a `Mutex`; the same shape as the usage write that
+    /// already runs on the finalize path.
+    ///
+    /// Failures are logged inside [`StateDb::upsert_session`] rather than
+    /// returned: persistence is a restart-recovery aid, and this step must
+    /// not introduce a new way for a healthy upload to fail.
+    pub fn persist_session(&self, id: &str, state: &FileState) {
+        let Some(db) = &self.shared.db else {
+            return;
+        };
+        let now = chrono::offset::Utc::now().timestamp();
+        db.upsert_session(&PersistedSession::from_state(id, state, now));
+    }
+
     pub fn remove(&self, id: &str) {
+        // A removed session can never be resumed, so its row goes too —
+        // otherwise it would outlive the on-disk file the caller deletes
+        // alongside this call.
+        if let Some(db) = &self.shared.db {
+            db.delete_session(id);
+        }
         let mut state = self.shared.state.lock().unwrap();
         state.files.remove(id);
         if let Some((when, removal_id)) = state.expiration_keys.remove(id) {
@@ -354,8 +671,8 @@ impl Store {
         // Persist to the source of truth first so a crash between the two
         // updates loses nothing: the cache is rebuilt from the database on
         // the next startup anyway.
-        if let Some(db) = &self.shared.usage_db {
-            db.record(&email, bytes, now);
+        if let Some(db) = &self.shared.db {
+            db.record_usage(&email, bytes, now);
         }
         let mut state = self.shared.state.lock().unwrap();
         let entry = state.usage.entry(email).or_default();
@@ -414,38 +731,55 @@ impl Drop for Store {
 
 impl SharedState {
     fn purge_expired(&self) -> Option<Instant> {
-        let mut state = self.state.lock().unwrap(); // this will only panic if we already panicked elsewhere while holding the mutex, which is fine.
+        let mut evicted: Vec<String> = Vec::new();
 
-        if state.shutdown {
-            return None;
-        }
+        let next_deadline = {
+            let mut state = self.state.lock().unwrap(); // this will only panic if we already panicked elsewhere while holding the mutex, which is fine.
 
-        let state = &mut *state; // needed for borrow checker
-
-        let now = Instant::now();
-        while let Some((&(when, removal_id), id)) = state.expirations.iter().next() {
-            if when > now {
-                return Some(when);
+            if state.shutdown {
+                return None;
             }
 
-            let id = id.clone();
-            if let Some(entry) = state.files.remove(&id) {
-                // An entry that still had no `sender` set was never finalized.
-                // (`sender` is populated by `upload_finalize` once the file has
-                // been unsealed.)
-                let was_unfinalized = entry
-                    .try_lock()
-                    .map(|g| g.sender.is_none())
-                    .unwrap_or(false);
-                if was_unfinalized {
-                    self.metrics.record_expired();
+            let state = &mut *state; // needed for borrow checker
+
+            let now = Instant::now();
+            loop {
+                let Some((&(when, removal_id), id)) = state.expirations.iter().next() else {
+                    break None;
+                };
+                if when > now {
+                    break Some(when);
                 }
+
+                let id = id.clone();
+                if let Some(entry) = state.files.remove(&id) {
+                    // An entry that still had no `sender` set was never finalized.
+                    // (`sender` is populated by `upload_finalize` once the file has
+                    // been unsealed.)
+                    let was_unfinalized = entry
+                        .try_lock()
+                        .map(|g| g.sender.is_none())
+                        .unwrap_or(false);
+                    if was_unfinalized {
+                        self.metrics.record_expired();
+                    }
+                }
+                state.expiration_keys.remove(&id);
+                state.expirations.remove(&(when, removal_id));
+                evicted.push(id);
             }
-            state.expiration_keys.remove(&id);
-            state.expirations.remove(&(when, removal_id));
+        };
+
+        // Outside the `state` mutex: an evicted session is unresumable, so its
+        // row goes with it. Without this the table would grow without bound
+        // and a restore would resurrect sessions the purge already killed.
+        if let Some(db) = &self.db {
+            for id in &evicted {
+                db.delete_session(id);
+            }
         }
 
-        None
+        next_deadline
     }
 
     fn is_shutdown(&self) -> bool {
@@ -600,7 +934,7 @@ mod tests {
     impl TempDbPath {
         fn new() -> Self {
             let path =
-                std::env::temp_dir().join(format!("cryptify-usage-{}.db", uuid::Uuid::new_v4()));
+                std::env::temp_dir().join(format!("cryptify-state-{}.db", uuid::Uuid::new_v4()));
             TempDbPath { path }
         }
 
@@ -738,5 +1072,298 @@ mod tests {
         assert_eq!(store.get_usage("c@example.com", now).used_bytes, 2_000);
         store.record_upload("c@example.com".into(), 3_000, now);
         assert_eq!(store.get_usage("c@example.com", now).used_bytes, 5_000);
+    }
+
+    // ---------------------------------------------------------------------
+    // Upload-session persistence (postguard#302).
+    //
+    // Rows are read back through a *second* `StateDb` on the same file, so
+    // these assert what a restarting process would actually find on disk
+    // rather than what the writing connection happens to hold.
+    // ---------------------------------------------------------------------
+
+    const RECIPIENTS: &str = "one@example.com, two@example.com";
+    const RECOVERY_TOKEN: &str = "3f7a9c1e-recovery-secret";
+
+    /// A `FileState` with every persisted field set to something
+    /// distinguishable, so a column swapped for its neighbour fails.
+    fn populated_filestate() -> FileState {
+        FileState {
+            uploaded: 0,
+            cryptify_token: "init-token".to_owned(),
+            expires: 1_700_000_000,
+            recipients: RECIPIENTS.parse().expect("parse recipients"),
+            mail_content: "hello <b>world</b>".to_owned(),
+            mail_lang: email::Language::Nl,
+            sender: None,
+            sender_attributes: Vec::new(),
+            confirm: true,
+            source_channel: "website".to_owned(),
+            client_version: Some("web,1.2,pg-js,2.3.3".to_owned()),
+            client_app: Some("pg-js".to_owned()),
+            notify_recipients: false,
+            api_key_tenant: Some("tenant-a".to_owned()),
+            api_key_validation_failed: false,
+            last_chunk: None,
+            recovery_token: RECOVERY_TOKEN.to_owned(),
+        }
+    }
+
+    /// Open a second connection to the same database file and read one row.
+    fn read_back(path: &str, uuid: &str) -> Option<PersistedSession> {
+        StateDb::open(path)
+            .expect("reopen state database")
+            .load_session(uuid)
+    }
+
+    #[rocket::async_test]
+    async fn create_persists_the_whole_session_row() {
+        let db = TempDbPath::new();
+        let store = store_with_db(db.as_str());
+        store.create("session-1".into(), populated_filestate());
+
+        let row = read_back(db.as_str(), "session-1").expect("row visible after init");
+        assert_eq!(row.uuid, "session-1");
+        assert_eq!(row.cryptify_token, "init-token");
+        assert_eq!(row.uploaded, 0);
+        assert_eq!(row.expires, 1_700_000_000);
+        assert_eq!(
+            row.recipients,
+            RECIPIENTS
+                .parse::<lettre::message::Mailboxes>()
+                .unwrap()
+                .to_string(),
+            "recipients round-trip through Mailboxes' Display"
+        );
+        assert_eq!(row.mail_content, "hello <b>world</b>");
+        assert_eq!(row.mail_lang, "NL");
+        assert!(row.confirm);
+        assert!(!row.notify_recipients);
+        assert_eq!(row.source_channel, "website");
+        assert_eq!(row.client_version.as_deref(), Some("web,1.2,pg-js,2.3.3"));
+        assert_eq!(row.client_app.as_deref(), Some("pg-js"));
+        assert_eq!(row.api_key_tenant.as_deref(), Some("tenant-a"));
+        assert!(!row.api_key_validation_failed);
+        assert_eq!(row.sender, None, "sender is unknown until finalize");
+        assert_eq!(row.sender_attributes, "[]");
+        // No chunk committed yet, so the whole replay record is absent.
+        assert_eq!(row.prev_token, None);
+        assert_eq!(row.prev_uploaded, None);
+        assert_eq!(row.response_token, None);
+        assert_eq!(
+            row.created_at, row.last_active_at,
+            "a session that has only been created has not been active since"
+        );
+    }
+
+    #[rocket::async_test]
+    async fn recovery_token_is_persisted_only_as_a_hash() {
+        let db = TempDbPath::new();
+        let store = store_with_db(db.as_str());
+        store.create("session-hash".into(), populated_filestate());
+
+        let row = read_back(db.as_str(), "session-hash").expect("row visible after init");
+        assert_eq!(row.recovery_token_hash, hash_recovery_token(RECOVERY_TOKEN));
+        assert_eq!(row.recovery_token_hash.len(), 64, "hex-encoded SHA-256");
+        // The bearer credential itself must not be recoverable from the row.
+        let serialized = format!("{:?}", row);
+        assert!(
+            !serialized.contains(RECOVERY_TOKEN),
+            "plaintext recovery token must not appear anywhere in the row: {serialized}"
+        );
+    }
+
+    #[rocket::async_test]
+    async fn an_accepted_chunk_persists_progress_and_keeps_created_at() {
+        let db = TempDbPath::new();
+        let store = store_with_db(db.as_str());
+        store.create("session-2".into(), populated_filestate());
+        let created_at = read_back(db.as_str(), "session-2")
+            .expect("row after init")
+            .created_at;
+
+        // Mirror what `upload_chunk` does to the live state before it calls
+        // `persist_session`: advance the chain and record the replay entry.
+        let handle = store.get("session-2").expect("live session");
+        {
+            let mut state = handle.lock().await;
+            state.cryptify_token = "chunk-1-token".to_owned();
+            state.uploaded = 1_048_576;
+            state.last_chunk = Some(LastChunkRecord {
+                prev_token: "init-token".to_owned(),
+                prev_uploaded: 0,
+                response_token: "chunk-1-token".to_owned(),
+            });
+            store.persist_session("session-2", &state);
+        }
+
+        let row = read_back(db.as_str(), "session-2").expect("row after chunk");
+        assert_eq!(row.cryptify_token, "chunk-1-token");
+        assert_eq!(row.uploaded, 1_048_576);
+        assert_eq!(row.prev_token.as_deref(), Some("init-token"));
+        assert_eq!(row.prev_uploaded, Some(0));
+        assert_eq!(row.response_token.as_deref(), Some("chunk-1-token"));
+        assert_eq!(
+            row.created_at, created_at,
+            "created_at records when the session began and must survive updates"
+        );
+        assert!(
+            row.last_active_at >= created_at,
+            "last_active_at should track the newest transition"
+        );
+        // Still exactly one row: the transition is an update, not an insert.
+        assert_eq!(
+            StateDb::open(db.as_str()).unwrap().session_count(),
+            1,
+            "a transition must upsert, not append"
+        );
+    }
+
+    #[rocket::async_test]
+    async fn finalize_persists_the_sender_and_its_attributes() {
+        let db = TempDbPath::new();
+        let store = store_with_db(db.as_str());
+        store.create("session-3".into(), populated_filestate());
+
+        let handle = store.get("session-3").expect("live session");
+        {
+            let mut state = handle.lock().await;
+            state.sender = Some("bob@example.com".to_owned());
+            state.sender_attributes = vec![(
+                "pbdf.gemeente.personalData.fullname".to_owned(),
+                "Bob".to_owned(),
+            )];
+            store.persist_session("session-3", &state);
+        }
+
+        let row = read_back(db.as_str(), "session-3").expect("row after finalize");
+        assert_eq!(row.sender.as_deref(), Some("bob@example.com"));
+        assert_eq!(
+            row.sender_attributes,
+            r#"[["pbdf.gemeente.personalData.fullname","Bob"]]"#
+        );
+    }
+
+    #[rocket::async_test]
+    async fn remove_deletes_the_persisted_row() {
+        let db = TempDbPath::new();
+        let store = store_with_db(db.as_str());
+        store.create("session-4".into(), populated_filestate());
+        assert!(read_back(db.as_str(), "session-4").is_some());
+
+        // What `upload_finalize` does when it rejects an upload for quota and
+        // deletes the on-disk file: the row must not outlive the file.
+        store.remove("session-4");
+        assert!(
+            read_back(db.as_str(), "session-4").is_none(),
+            "removing a session must delete its row"
+        );
+    }
+
+    #[rocket::async_test]
+    async fn eviction_deletes_the_persisted_row() {
+        let db = TempDbPath::new();
+        // Idle window short enough that the purge task fires during the test.
+        let store = Store::with_idle_ttl(
+            Duration::from_millis(20),
+            Arc::new(Metrics::new()),
+            Some(db.as_str()),
+        );
+        store.create("session-5".into(), populated_filestate());
+        assert!(read_back(db.as_str(), "session-5").is_some());
+
+        // Poll rather than sleep a fixed interval: the purge task is a real
+        // background task, and a loaded CI runner can be slow to schedule it.
+        let mut evicted = false;
+        for _ in 0..100 {
+            rocket::tokio::time::sleep(Duration::from_millis(20)).await;
+            if read_back(db.as_str(), "session-5").is_none() {
+                evicted = true;
+                break;
+            }
+        }
+        assert!(
+            evicted,
+            "the purge task must delete the row of a session it evicts"
+        );
+        assert!(
+            store.get("session-5").is_none(),
+            "in-memory eviction should have happened too"
+        );
+    }
+
+    #[rocket::async_test]
+    async fn persistence_is_a_noop_without_a_configured_database() {
+        // The `usage_db`-unset deployment keeps the old in-memory behaviour;
+        // every persistence call has to degrade to nothing rather than panic.
+        let store = Store::new(Arc::new(Metrics::new()));
+        store.create("session-6".into(), populated_filestate());
+        let handle = store.get("session-6").expect("live session");
+        {
+            let state = handle.lock().await;
+            store.persist_session("session-6", &state);
+        }
+        store.remove("session-6");
+        assert!(store.get("session-6").is_none());
+    }
+
+    #[rocket::async_test]
+    async fn schema_is_created_on_boot_and_survives_reopening() {
+        let db = TempDbPath::new();
+        {
+            // First boot creates the schema in a database file that does not
+            // exist yet.
+            let store = store_with_db(db.as_str());
+            store.create("session-7".into(), populated_filestate());
+        }
+        // Second boot must find the table already there (CREATE TABLE IF NOT
+        // EXISTS) and leave the existing row alone. Reading the row back is
+        // all this step promises — rebuilding sessions from it is #303.
+        let store = store_with_db(db.as_str());
+        assert!(
+            store.get("session-7").is_none(),
+            "restore-on-boot is postguard#303 and must not happen yet"
+        );
+        assert!(
+            read_back(db.as_str(), "session-7").is_some(),
+            "the row must still be there after a reopen"
+        );
+    }
+
+    #[rocket::async_test]
+    async fn a_usage_only_database_gains_the_sessions_table_on_next_boot() {
+        // Deployments already running with `usage_db` set have a file with
+        // just the `usage` table. Opening it must add `upload_sessions` in
+        // place, without disturbing the usage rows.
+        let db = TempDbPath::new();
+        {
+            let conn = rusqlite::Connection::open(db.as_str()).expect("open bare database");
+            conn.execute(
+                "CREATE TABLE usage (
+                     email     TEXT    NOT NULL,
+                     timestamp INTEGER NOT NULL,
+                     bytes     INTEGER NOT NULL
+                 )",
+                [],
+            )
+            .expect("create legacy usage table");
+            conn.execute(
+                "INSERT INTO usage (email, timestamp, bytes) VALUES ('old@example.com', 1000, 4242)",
+                [],
+            )
+            .expect("seed a usage row");
+        }
+
+        let store = store_with_db(db.as_str());
+        assert_eq!(
+            store.get_usage("old@example.com", 1_000).used_bytes,
+            4242,
+            "pre-existing usage rows must still load"
+        );
+        store.create("session-8".into(), populated_filestate());
+        assert!(
+            read_back(db.as_str(), "session-8").is_some(),
+            "the upload_sessions table must be created in an existing database"
+        );
     }
 }


### PR DESCRIPTION
Closes #302. First half of #300 (epic #247, workstream E); restore-on-boot is #303 and is deliberately **not** here.

## What this changes

Upload sessions lived only in `Store`'s in-memory map, so any restart lost every in-flight upload. This makes the state durable **without changing a single response**: every transition is written through to SQLite, and nothing reads the rows back yet.

`usage_db` now names cryptify's whole state database rather than just the quota table: one file, one `rusqlite::Connection` behind one `Mutex` (`StateDb`), two tables. `upload_sessions` is created with `CREATE TABLE IF NOT EXISTS` at startup, so a database already holding usage rows gains it in place, and `usage_db` unset still means in-memory only. The key name was left alone on purpose — renaming it would be an ops-visible change for zero behavioural gain.

`Store::persist_session` writes one upsert and runs **before the handler responds**, at each of the three transitions:

| transition | call site |
| --- | --- |
| init | `Store::create` (before the entry is visible in memory) |
| chunk accepted | `upload_chunk`, once the rolling token has advanced |
| finalize | `upload_finalize`, right after the unsealed `sender` is known, before the email |

The reverse edges matter as much, so `Store::remove` and the purge task both delete the row — an unresumable session must not leave one behind, or the table would grow without bound and a future restore would resurrect sessions the purge already killed. Database errors are logged rather than propagated: persistence must not add a way for a healthy upload to fail.

## Three schema decisions worth calling out

- **The recovery token is stored as a hex SHA-256**, never as the plaintext bearer credential for `GET /fileupload/{uuid}/status`. A restore path compares `sha256(presented)` against the column.
- **`created_at` is absent from the upsert's `DO UPDATE SET` list.** That omission is what keeps it recording when the session began; `last_active_at` moves on every transition.
- **There is no expected-size column.** Clients send `Content-Range: bytes <s>-<e>/*` on chunk PUTs, so the total is genuinely unknown to the server until finalize declares it (and finalize rejects a declaration that disagrees with `uploaded`).

## Coverage

12 new tests, all reading rows back over a *second* connection to the same file so they assert what a restarting process would actually find on disk rather than what the writing connection holds:

- `store.rs`: the full row after init; progress plus a preserved `created_at` after a chunk (and that it upserts rather than appends); the sender after finalize; deletion on `remove` and on eviction; the recovery token present only as a hash; the no-database no-op path; schema creation on first boot and on reopen; a usage-only database gaining the table without disturbing its usage rows.
- `main.rs` `mod integration`, through the `build_rocket` seam with `usage_db` pointed inside the per-test `data_dir`: real HTTP init → chunk → finalize, with the columns read back using plain SQL. `session_rows_are_visible_in_sqlite_after_init_and_chunk` is the ticket's done bar, and it asserts the persisted token is the one the client was handed. `upload_happy_path_is_unchanged_with_persistence_enabled` pins the no-visible-change claim.
- `email.rs`: `language_code_matches_serde_representation` pins the new `Language::code()` (what the `mail_lang` column stores) to the serde/wire form.

`cargo test -p cryptify --all-targets` → 170 passed, 0 failed. `cargo clippy -p cryptify --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean. No dependency changes — this uses the `rusqlite` already in the lockfile (the sqlx/rusqlite `links = "sqlite3"` coupling in root `CLAUDE.md` is untouched).

`cryptify/CLAUDE.md` is updated in the same commit, including the fact that prod's `conf/config.toml` does not set `usage_db` at all — so session persistence is off in any deployment that never set it, which #303 will need to know.