### PR TITLE
fix: copy the cryptify member into dev.Dockerfile's planner stage

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,11 +4,20 @@ RUN cargo install cargo-chef cargo-watch
 WORKDIR /app
 
 FROM chef AS planner
+# Every workspace member listed in the root Cargo.toml has to be copied, even
+# when this image only builds pg-pkg: `cargo chef prepare` shells out to
+# `cargo metadata`, which reads the manifest of every member and fails the whole
+# build if one is absent. cryptify became a member in #277 and was missed, which
+# broke this image (and postguard-e2e's stack, which builds it) with
+# `failed to load manifest for workspace member /app/cryptify`.
+# pg-wasm is in `exclude` rather than `members`, so it is not needed for that —
+# it is copied because the image is also used to build it.
 COPY pg-core ./pg-core
 COPY pg-pkg ./pg-pkg
 COPY pg-cli ./pg-cli
 COPY pg-ffi ./pg-ffi
 COPY pg-wasm ./pg-wasm
+COPY cryptify ./cryptify
 COPY Cargo.toml Cargo.lock ./
 RUN cargo chef prepare --recipe-path recipe.json
 RUN cargo run --bin pg-pkg -- gen


### PR DESCRIPTION
Found while auditing the archived repos' channels (#312) — unrelated to that audit, but it is breaking a live repo's CI daily, so it gets its own PR rather than a note.

## The bug

`dev.Dockerfile`'s planner stage copies each workspace member before `cargo chef prepare`. `cryptify` was never added when it became a member in #277. `cargo chef prepare` shells out to `cargo metadata`, which reads the manifest of **every** member, so the build dies:

```
error: failed to load manifest for workspace member `/app/cryptify`
referenced by workspace at `/app/Cargo.toml`
Caused by: failed to read `/app/cryptify/Cargo.toml`
```

The trap is that this image builds only `pg-pkg`, so a missing *unrelated* member reads as though it should be harmless. It is not: `cargo metadata` is workspace-wide before any target selection happens. Hence the comment on the COPY block.

## Impact

`postguard-e2e`'s stack builds this image, so its `e2e` workflow has failed at the `Build stack images (GHA layer cache)` step on every scheduled run since the merge — 2026-08-07, -08, -09 and -10, all on the same sha. The golden-flow leg never got to execute, so the e2e suite has been dark for four days while reporting a specific, unrelated-looking Docker error.

## Verification

The failing command is plain cargo, so this reproduces without Docker: copy exactly the paths the planner stage copies into an empty directory, add the root `Cargo.toml`/`Cargo.lock`, and run `cargo metadata --no-deps`.

| Context | Exit |
|---|---|
| `pg-core pg-pkg pg-cli pg-ffi pg-wasm` + root manifest | `101`, with the error above |
| the same **plus `cryptify`** | `0` |

`pg-wasm` stays in the list even though it is in `exclude` rather than `members` — it is not needed to satisfy `cargo metadata`, but the image is also used to build it.